### PR TITLE
Add indexed fold functions

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -19,7 +19,7 @@ module List.Extra exposing ( last
   , filterNot
   , iterate
   , intercalate, transpose, subsequences, permutations, interweave
-  , foldl1, foldr1
+  , foldl1, foldr1, indexedFoldl, indexedFoldr
   , scanl1, scanr, scanr1, unfoldr
   , splitAt, takeWhileRight, dropWhileRight, span, break, stripPrefix
   , group, groupWhile, groupWhileTransitively, inits, tails, select, selectSplit
@@ -505,21 +505,19 @@ foldr1 f xs =
   in
     List.foldr mf Nothing xs
 
-{-| Variant of `foldl` that passes the index of the current element to the reducer function. `indexedFoldl` is to `List.foldl` as `List.indexedMap` is to `List.map`.
+{-| Variant of `foldl` that passes the index of the current element to the step function. `indexedFoldl` is to `List.foldl` as `List.indexedMap` is to `List.map`.
 -}
-indexedFoldl : (a -> Int -> b -> b) -> b -> List a -> b
+indexedFoldl : (Int -> a -> b -> b) -> b -> List a -> b
 indexedFoldl func acc list =
-  list
-    |> List.foldl (\x (i, acc) -> (i + 1, func x i acc)) (0, acc)
-    |> snd
+  let step x (i, acc) = (i + 1, func i x acc)
+  in snd (List.foldl step (0, acc) list)
 
-{-| Variant of `foldr` that passes the index of the current element to the reducer function. `indexedFoldr` is to `List.foldr` as `List.indexedMap` is to `List.map`.
+{-| Variant of `foldr` that passes the index of the current element to the step function. `indexedFoldr` is to `List.foldr` as `List.indexedMap` is to `List.map`.
 -}
-indexedFoldr : (a -> Int -> b -> b) -> b -> List a -> b
+indexedFoldr : (Int -> a -> b -> b) -> b -> List a -> b
 indexedFoldr func acc list =
-  list
-    |> List.foldr (\x (i, acc) -> (i - 1, func x i acc)) (List.length list - 1, acc)
-    |> snd
+  let step x (i, acc) = (i - 1, func i x acc)
+  in snd (List.foldr step (List.length list - 1, acc) list)
 
 {-| `scanl1` is a variant of `scanl` that has no starting value argument.
 

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -44,7 +44,7 @@ module List.Extra exposing ( last
 @docs intercalate, transpose, subsequences, permutations, interweave
 
 # Folds
-@docs foldl1, foldr1
+@docs foldl1, foldr1, indexedFoldl, indexedFoldr
 
 # Building lists
 @docs scanl1, scanr, scanr1, unfoldr, iterate
@@ -504,6 +504,22 @@ foldr1 f xs =
                      Just y -> f x y)
   in
     List.foldr mf Nothing xs
+
+{-| Variant of `foldl` that passes the index of the current element to the reducer function. `indexedFoldl` is to `List.foldl` as `List.indexedMap` is to `List.map`.
+-}
+indexedFoldl : (a -> Int -> b -> b) -> b -> List a -> b
+indexedFoldl func acc list =
+  list
+    |> List.foldl (\x (i, acc) -> (i + 1, func x i acc)) (0, acc)
+    |> snd
+
+{-| Variant of `foldr` that passes the index of the current element to the reducer function. `indexedFoldr` is to `List.foldr` as `List.indexedMap` is to `List.map`.
+-}
+indexedFoldr : (a -> Int -> b -> b) -> b -> List a -> b
+indexedFoldr func acc list =
+  list
+    |> List.foldr (\x (i, acc) -> (i - 1, func x i acc)) (List.length list - 1, acc)
+    |> snd
 
 {-| `scanl1` is a variant of `scanl` that has no starting value argument.
 


### PR DESCRIPTION
I was missing the index parameter available in JavaScript's reduce and reduceRight. These changes add indexedFoldl and indexedFoldr to handle use cases where that parameter is helpful/necessary. These functions are identical to List.foldl and List.foldr except that the index of the current element being processed is passed to the reducer function along with the element itself.
