### PR TITLE
Add swapAt function.

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -10,6 +10,7 @@ module List.Extra exposing ( last
   , unique, uniqueBy
   , replaceIf
   , setAt
+  , swapAt
   , remove
   , updateIf
   , updateAt
@@ -38,7 +39,7 @@ module List.Extra exposing ( last
 {-| Convenience functions for working with List
 
 # Basics
-@docs last, init, getAt, (!!), uncons, maximumBy, minimumBy, andMap, andThen, takeWhile, dropWhile, unique, uniqueBy, replaceIf, setAt, remove, updateIf, updateAt, updateIfIndex, singleton, removeAt, filterNot
+@docs last, init, getAt, (!!), uncons, maximumBy, minimumBy, andMap, andThen, takeWhile, dropWhile, unique, uniqueBy, replaceIf, setAt, swapAt, remove, updateIf, updateAt, updateIfIndex, singleton, removeAt, filterNot
 
 # List transformations
 @docs intercalate, transpose, subsequences, permutations, interweave
@@ -357,6 +358,33 @@ setAt index value l =
 
         Just t ->
           Just (value :: t |> List.append head)
+
+{-| Swap two values in a list by index. Returns the updated list if both indices
+are in range, or Nothing if both are out of range. If the same index is
+supplied twice the original list is returned.
+ -}
+swapAt : Int -> Int -> List a -> Maybe (List a)
+swapAt index1 index2 l =
+  if index1 == index2 then
+    Just l
+  else if index1 > index2 then
+    swapAt index2 index1 l
+  else if index1 < 0 then
+    Nothing
+  else
+    let
+      ( part1, tail1 ) =
+        splitAt index1 l
+
+      ( head2, tail2 ) =
+        splitAt (index2 - index1) tail1
+    in
+      Maybe.map2
+        (\( value1, part2 ) ( value2, part3 ) ->
+          List.concat [ part1, value2 :: part2, value1 :: part3 ]
+        )
+        (uncons head2)
+        (uncons tail2)
 
 
 {-| Convert a value to a list containing one value.


### PR DESCRIPTION
This pull request adds the swapAt function to list-extra. It can swap two values in a list by index. Returns the updated list if both indices are in range, or Nothing if both are out of range. If the same index is supplied twice the original list is returned.

This could be implemented using getAt, setAt but that would deconstruct and reconstruct the list multiple times. It also requires more Maybe wrangling.
