### PR TITLE
Make isPrefixOf non-symmetrical

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -368,8 +368,8 @@ andThen =
 
 {-| Negation of `member`.
 
-    1 `notMember` [1,2,3] == False
-    4 `notMember` [1,2,3] == True
+    notMember 1 [1,2,3] == False
+    notMember 4 [1,2,3] == True
 -}
 notMember : a -> List a -> Bool
 notMember x =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -296,11 +296,11 @@ uniqueBy f list =
 
 {-| Indicate if list has duplicate values.
 
-    allDifferent [0,1,1,0,1] == True
+    allDifferent [0,1,1,0,1] == False
 -}
 allDifferent : List comparable -> Bool
 allDifferent list =
-    List.length list == List.length (unique list)
+    allDifferentBy identity list
 
 
 {-| Indicate if list has duplicate values when supplied function are applyed on each values.
@@ -797,7 +797,7 @@ Compare:
     scanl1 (-) [1,2,3] == [1,1,2]
 
     List.scanl (flip (-)) 0 [1,2,3] == [0,-1,-3,-6]
-    scanl1 (flip (-)) [1,2,3] == [1,-1,4]
+    scanl1 (flip (-)) [1,2,3] == [1,-1,-4]
 -}
 scanl1 : (a -> a -> a) -> List a -> List a
 scanl1 f xs_ =
@@ -919,9 +919,9 @@ dropWhileRight p =
 
 {-| Take a predicate and a list, return a tuple. The first part of the tuple is the longest prefix of that list, for each element of which the predicate holds. The second part of the tuple is the remainder of the list. `span p xs` is equivalent to `(takeWhile p xs, dropWhile p xs)`.
 
-    span (< 3) [1,2,3,4,1,2,3,4] == ([1,2],[3,4,1,2,3,4])
-    span (< 5) [1,2,3] == ([1,2,3],[])
-    span (< 0) [1,2,3] == ([],[1,2,3])
+    span ((>) 3) [1,2,3,4,1,2,3,4] == ([1,2],[3,4,1,2,3,4])
+    span ((>) 5) [1,2,3] == ([1,2,3],[])
+    span ((>) 0) [1,2,3] == ([],[1,2,3])
 -}
 span : (a -> Bool) -> List a -> ( List a, List a )
 span p xs =
@@ -930,9 +930,9 @@ span p xs =
 
 {-| Take a predicate and a list, return a tuple. The first part of the tuple is the longest prefix of that list, for each element of which the predicate *does not* hold. The second part of the tuple is the remainder of the list. `break p xs` is equivalent to `(takeWhile (not p) xs, dropWhile (not p) xs)`.
 
-    break (> 3) [1,2,3,4,1,2,3,4] == ([1,2,3],[4,1,2,3,4])
-    break (< 5) [1,2,3] == ([],[1,2,3])
-    break (> 5) [1,2,3] == ([1,2,3],[])
+    break ((<) 3) [1,2,3,4,1,2,3,4] == ([1,2,3],[4,1,2,3,4])
+    break ((>) 5) [1,2,3] == ([],[1,2,3])
+    break ((<) 5) [1,2,3] == ([1,2,3],[])
 -}
 break : (a -> Bool) -> List a -> ( List a, List a )
 break p =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1084,8 +1084,16 @@ selectSplit xs =
 {-| Take 2 lists and return True, if the first list is the prefix of the second list.
 -}
 isPrefixOf : List a -> List a -> Bool
-isPrefixOf prefix =
-    all identity << map2 (==) prefix
+isPrefixOf prefix xs =
+    case ( prefix, xs ) of
+        ( [], _ ) ->
+            True
+
+        ( _ :: _, [] ) ->
+            False
+
+        ( p :: ps, x :: xs ) ->
+            p == x && isPrefixOf ps xs
 
 
 {-| Take 2 lists and return True, if the first list is the suffix of the second list.

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -329,14 +329,14 @@ uniqueHelp f existing remaining =
 
 {-| Map functions taking multiple arguments over multiple lists. Each list should be of the same length.
 
-    ( (\a b c -> a + b * c)
-        `map` [1,2,3]
-        `andMap` [4,5,6]
-        `andMap` [2,1,1]
+    ((\a b c -> a + b * c)
+        |> map [1,2,3]
+        |> andMap [4,5,6]
+        |> andMap [2,1,1]
     ) == [9,7,9]
 -}
-andMap : List (a -> b) -> List a -> List b
-andMap fl l =
+andMap : List a -> List (a -> b) -> List b
+andMap l fl =
     map2 (<|) fl l
 
 

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -887,7 +887,7 @@ splitAt n xs =
 
 {-| Take elements from the right, while predicate still holds.
 
-    takeWhileRight ((<)5) [1..10] == [6,7,8,9,10]
+    takeWhileRight ((<)5) (range 1 10) == [6,7,8,9,10]
 -}
 takeWhileRight : (a -> Bool) -> List a -> List a
 takeWhileRight p =
@@ -903,7 +903,7 @@ takeWhileRight p =
 
 {-| Drop elements from the right, while predicate still holds.
 
-    dropWhileRight ((<)5) [1..10] == [1,2,3,4,5]
+    dropWhileRight ((<)5) (range 1 10) == [1,2,3,4,5]
 -}
 dropWhileRight : (a -> Bool) -> List a -> List a
 dropWhileRight p =
@@ -1170,8 +1170,7 @@ lift4 f la lb lc ld =
 
 {-| Split list into groups of size given by the first argument.
 
-    groupsOf 3 [1..10]
-      == [[1,2,3],[4,5,6],[7,8,9]]
+    groupsOf 3 (range 1 10) == [[1,2,3],[4,5,6],[7,8,9]]
 -}
 groupsOf : Int -> List a -> List (List a)
 groupsOf size xs =
@@ -1180,8 +1179,7 @@ groupsOf size xs =
 
 {-| Split list into groups of size given by the first argument.  After each group, drop a number of elements given by the second argument before starting the next group.
 
-    groupsOfWithStep 2 1 [1..4]
-      == [[1,2],[2,3],[3,4]]
+    groupsOfWithStep 2 1 (range 1 4) == [[1,2],[2,3],[3,4]]
 -}
 groupsOfWithStep : Int -> Int -> List a -> List (List a)
 groupsOfWithStep size step xs =
@@ -1231,8 +1229,7 @@ groupsOfVarying_ listOflengths list accu =
 
 {-| Split list into groups of size given by the first argument "greedily" (don't throw the group away if not long enough).
 
-    greedyGroupsOf 3 [1..10]
-      == [[1,2,3],[4,5,6],[7,8,9],[10]]
+    greedyGroupsOf 3 (range 1 10) == [[1,2,3],[4,5,6],[7,8,9],[10]]
 -}
 greedyGroupsOf : Int -> List a -> List (List a)
 greedyGroupsOf size xs =
@@ -1241,8 +1238,7 @@ greedyGroupsOf size xs =
 
 {-| Split list into groups of size given by the first argument "greedily" (don't throw the group away if not long enough). After each group, drop a number of elements given by the second argumet before starting the next group.
 
-    greedyGroupsOfWithStep 3 2 [1..6]
-      == [[1,2,3],[3,4,5],[5,6]]
+    greedyGroupsOfWithStep 3 2 (range 1 6) == [[1,2,3],[3,4,5],[5,6]]
 -}
 greedyGroupsOfWithStep : Int -> Int -> List a -> List (List a)
 greedyGroupsOfWithStep size step xs =

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/elm-stuff/

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,0 +1,13 @@
+port module Main exposing (..)
+
+import Tests
+import Test.Runner.Node exposing (run, TestProgram)
+import Json.Encode exposing (Value)
+
+
+main : TestProgram
+main =
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,355 @@
+module Tests exposing (..)
+
+import Test exposing (..)
+import Expect
+import Fuzz exposing (list, int, tuple3)
+import List exposing (map, range)
+import Tuple exposing (first)
+import List.Extra exposing (..)
+
+
+all : Test
+all =
+    describe "List.Extra"
+        [ describe "unique" <|
+            [ test "removes duplicates" <|
+                \() ->
+                    Expect.equal (List.Extra.unique [ 0, 1, 1, 0, 1 ]) [ 0, 1 ]
+            ]
+        , describe "allDifferent" <|
+            [ test "detects duplicates" <|
+                \() ->
+                    Expect.equal (List.Extra.allDifferent [ 0, 1, 1, 0, 1 ]) False
+            ]
+        , describe "andMap" <|
+            [ test "computes piecemeal" <|
+                \() ->
+                    Expect.equal
+                        ([ 1, 2, 3 ]
+                            |> map (\a b c -> a + b * c)
+                            |> andMap [ 4, 5, 6 ]
+                            |> andMap [ 2, 1, 1 ]
+                        )
+                        [ 9, 7, 9 ]
+            ]
+        , describe "notMember" <|
+            [ test "disconfirms member" <|
+                \() ->
+                    Expect.equal (notMember 1 [ 1, 2, 3 ]) False
+            , test "confirms non-member" <|
+                \() ->
+                    Expect.equal (notMember 4 [ 1, 2, 3 ]) True
+            ]
+        , describe "find" <|
+            [ test "behaves as documented" <|
+                \() ->
+                    Expect.equal (find (\num -> num > 5) [ 2, 4, 6, 8 ]) (Just 6)
+            ]
+        , describe "elemIndex" <|
+            [ test "finds index of value" <|
+                \() ->
+                    Expect.equal (elemIndex 1 [ 1, 2, 3 ]) (Just 0)
+            , test "doesn't find index of non-present" <|
+                \() ->
+                    Expect.equal (elemIndex 4 [ 1, 2, 3 ]) Nothing
+            , test "finds index of first match" <|
+                \() ->
+                    Expect.equal (elemIndex 1 [ 1, 2, 1 ]) (Just 0)
+            ]
+        , describe "elemIndices" <|
+            [ test "finds singleton index" <|
+                \() ->
+                    Expect.equal (elemIndices 1 [ 1, 2, 3 ]) [ 0 ]
+            , test "doesn't find indices of non-present" <|
+                \() ->
+                    Expect.equal (elemIndices 4 [ 1, 2, 3 ]) []
+            , test "finds all indices" <|
+                \() ->
+                    Expect.equal (elemIndices 1 [ 1, 2, 1 ]) [ 0, 2 ]
+            ]
+        , describe "findIndex" <|
+            [ test "finds index of value" <|
+                \() ->
+                    Expect.equal (findIndex (\x -> x % 2 == 0) [ 1, 2, 3 ]) (Just 1)
+            , test "doesn't find index of non-present" <|
+                \() ->
+                    Expect.equal (findIndex (\x -> x % 2 == 0) [ 1, 3, 5 ]) Nothing
+            , test "finds index of first match" <|
+                \() ->
+                    Expect.equal (findIndex (\x -> x % 2 == 0) [ 1, 2, 4 ]) (Just 1)
+            ]
+        , describe "findIndices" <|
+            [ test "finds singleton index" <|
+                \() ->
+                    Expect.equal (findIndices (\x -> x % 2 == 0) [ 1, 2, 3 ]) [ 1 ]
+            , test "doesn't find indices of non-present" <|
+                \() ->
+                    Expect.equal (findIndices (\x -> x % 2 == 0) [ 1, 3, 5 ]) []
+            , test "finds all indices" <|
+                \() ->
+                    Expect.equal (findIndices (\x -> x % 2 == 0) [ 1, 2, 4 ]) [ 1, 2 ]
+            ]
+        , describe "intercalate" <|
+            [ test "computes example" <|
+                \() ->
+                    Expect.equal
+                        (intercalate [ 0, 0 ] [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ])
+                        [ 1, 2, 0, 0, 3, 4, 0, 0, 5, 6 ]
+            ]
+        , describe "transpose" <|
+            [ test "performs basic transpose" <|
+                \() ->
+                    Expect.equal
+                        (transpose [ [ 1, 2, 3 ], [ 4, 5, 6 ] ])
+                        [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+            , test "short rows are skipped" <|
+                \() ->
+                    Expect.equal
+                        (transpose [ [ 10, 11 ], [ 20 ], [], [ 30, 31, 32 ] ])
+                        [ [ 10, 20, 30 ], [ 11, 31 ], [ 32 ] ]
+            ]
+        , describe "subsequences" <|
+            [ test "computes subsequences" <|
+                \() ->
+                    Expect.equal
+                        (subsequences [ 1, 2, 3 ])
+                        [ [], [ 1 ], [ 2 ], [ 1, 2 ], [ 3 ], [ 1, 3 ], [ 2, 3 ], [ 1, 2, 3 ] ]
+            ]
+        , describe "permutations" <|
+            [ test "computes permutations" <|
+                \() ->
+                    Expect.equal
+                        (permutations [ 1, 2, 3 ])
+                        [ [ 1, 2, 3 ], [ 1, 3, 2 ], [ 2, 1, 3 ], [ 2, 3, 1 ], [ 3, 1, 2 ], [ 3, 2, 1 ] ]
+            ]
+        , describe "interweave" <|
+            [ test "interweaves lists of equal length" <|
+                \() ->
+                    Expect.equal (interweave [ 1, 3 ] [ 2, 4 ]) [ 1, 2, 3, 4 ]
+            , test "appends remaining members of longer list" <|
+                \() ->
+                    Expect.equal (interweave [ 1, 3, 5, 7 ] [ 2, 4 ]) [ 1, 2, 3, 4, 5, 7 ]
+            ]
+        , describe "foldl1" <|
+            [ test "computes maximum" <|
+                \() ->
+                    Expect.equal (foldl1 max [ 1, 2, 3, 2, 1 ]) (Just 3)
+            , test "falls back to Nothing" <|
+                \() ->
+                    Expect.equal (foldl1 max []) Nothing
+            , test "computes left to right difference" <|
+                \() ->
+                    Expect.equal (foldl1 (-) [ 1, 2, 3 ]) (Just -4)
+            ]
+        , describe "foldr1" <|
+            [ test "computes minimum" <|
+                \() ->
+                    Expect.equal (foldr1 min [ 1, 2, 3, 2, 1 ]) (Just 1)
+            , test "falls back to Nothing" <|
+                \() ->
+                    Expect.equal (foldr1 min []) Nothing
+            , test "computes right to left difference" <|
+                \() ->
+                    Expect.equal (foldr1 (-) [ 1, 2, 3 ]) (Just 2)
+            ]
+        , describe "scanl1" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (scanl1 (+) [ 1, 2, 3 ]) [ 1, 3, 6 ]
+            , test "" <|
+                \() ->
+                    Expect.equal (scanl1 (-) [ 1, 2, 3 ]) [ 1, 1, 2 ]
+            , test "" <|
+                \() ->
+                    Expect.equal (scanl1 (flip (-)) [ 1, 2, 3 ]) [ 1, -1, -4 ]
+            ]
+        , describe "scanr" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (scanr (+) 0 [ 1, 2, 3 ]) [ 6, 5, 3, 0 ]
+            , test "" <|
+                \() ->
+                    Expect.equal (scanr (-) 0 [ 1, 2, 3 ]) [ 2, -1, 3, 0 ]
+            ]
+        , describe "scanr1" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (scanr1 (+) [ 1, 2, 3 ]) [ 6, 5, 3 ]
+            , test "" <|
+                \() ->
+                    Expect.equal (scanr1 (-) [ 1, 2, 3 ]) [ 2, -1, 3 ]
+            , test "" <|
+                \() ->
+                    Expect.equal (scanr1 (flip (-)) [ 1, 2, 3 ]) [ 0, 1, 3 ]
+            ]
+        , describe "unfoldr" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal
+                        (unfoldr
+                            (\b ->
+                                if b == 0 then
+                                    Nothing
+                                else
+                                    Just ( b, b - 1 )
+                            )
+                            5
+                        )
+                        [ 5, 4, 3, 2, 1 ]
+            ]
+        , describe "splitAt" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (splitAt 3 [ 1, 2, 3, 4, 5 ]) ( [ 1, 2, 3 ], [ 4, 5 ] )
+            , test "" <|
+                \() ->
+                    Expect.equal (splitAt 1 [ 1, 2, 3 ]) ( [ 1 ], [ 2, 3 ] )
+            , test "" <|
+                \() ->
+                    Expect.equal (splitAt 3 [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
+            , test "" <|
+                \() ->
+                    Expect.equal (splitAt 4 [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
+            , test "" <|
+                \() ->
+                    Expect.equal (splitAt 0 [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
+            , test "" <|
+                \() ->
+                    Expect.equal (splitAt (-1) [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
+            ]
+        , describe "takeWhileRight" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (takeWhileRight ((<) 5) (range 1 10)) [ 6, 7, 8, 9, 10 ]
+            , test "" <|
+                \() ->
+                    Expect.equal (dropWhileRight ((<) 5) (range 1 10)) [ 1, 2, 3, 4, 5 ]
+            ]
+        , describe "span" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (span ((>) 3) [ 1, 2, 3, 4, 1, 2, 3, 4 ]) ( [ 1, 2 ], [ 3, 4, 1, 2, 3, 4 ] )
+            , test "" <|
+                \() ->
+                    Expect.equal (span ((>) 5) [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
+            , test "" <|
+                \() ->
+                    Expect.equal (span ((>) 0) [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
+            ]
+        , describe "break" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (break ((<) 3) [ 1, 2, 3, 4, 1, 2, 3, 4 ]) ( [ 1, 2, 3 ], [ 4, 1, 2, 3, 4 ] )
+            , test "" <|
+                \() ->
+                    Expect.equal (break ((>) 5) [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
+            , test "" <|
+                \() ->
+                    Expect.equal (break ((<) 5) [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
+            ]
+        , describe "stripPrefix" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (stripPrefix [ 1, 2 ] [ 1, 2, 3, 4 ]) (Just [ 3, 4 ])
+            , test "" <|
+                \() ->
+                    Expect.equal (stripPrefix [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ]) (Just [ 4, 5 ])
+            , test "" <|
+                \() ->
+                    Expect.equal (stripPrefix [ 1, 2, 3 ] [ 1, 2, 3 ]) (Just [])
+            , test "" <|
+                \() ->
+                    Expect.equal (stripPrefix [ 1, 2, 3 ] [ 1, 2 ]) Nothing
+            , test "" <|
+                \() ->
+                    Expect.equal (stripPrefix [ 3, 2, 1 ] [ 1, 2, 3, 4, 5 ]) Nothing
+            ]
+        , describe "group" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (group [ 1, 2, 2, 3, 3, 3, 2, 2, 1 ]) [ [ 1 ], [ 2, 2 ], [ 3, 3, 3 ], [ 2, 2 ], [ 1 ] ]
+            ]
+        , describe "groupWhile" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal
+                        (groupWhile (\x y -> first x == first y) [ ( 0, 'a' ), ( 0, 'b' ), ( 1, 'c' ), ( 1, 'd' ) ])
+                        [ [ ( 0, 'a' ), ( 0, 'b' ) ], [ ( 1, 'c' ), ( 1, 'd' ) ] ]
+            , test "" <|
+                \() ->
+                    Expect.equal
+                        (groupWhile (<) [ 1, 2, 3, 2, 4, 1, 3, 2, 1 ])
+                        [ [ 1, 2, 3, 2, 4 ], [ 1, 3, 2 ], [ 1 ] ]
+            ]
+        , describe "groupWhileTransitively" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal
+                        (groupWhileTransitively (<) [ 1, 2, 3, 2, 4, 1, 3, 2, 1 ])
+                        [ [ 1, 2, 3 ], [ 2, 4 ], [ 1, 3 ], [ 2 ], [ 1 ] ]
+            ]
+        , describe "inits" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (inits [ 1, 2, 3 ]) [ [], [ 1 ], [ 1, 2 ], [ 1, 2, 3 ] ]
+            ]
+        , describe "tails" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (tails [ 1, 2, 3 ]) [ [ 1, 2, 3 ], [ 2, 3 ], [ 3 ], [] ]
+            ]
+        , describe "select" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal
+                        (select [ 1, 2, 3, 4 ])
+                        [ ( 1, [ 2, 3, 4 ] ), ( 2, [ 1, 3, 4 ] ), ( 3, [ 1, 2, 4 ] ), ( 4, [ 1, 2, 3 ] ) ]
+            ]
+        , describe "selectSplit" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (selectSplit [ 1, 2, 3 ]) [ ( [], 1, [ 2, 3 ] ), ( [ 1 ], 2, [ 3 ] ), ( [ 1, 2 ], 3, [] ) ]
+            ]
+        , describe "lift2" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (lift2 (+) [ 1, 2, 3 ] [ 4, 5 ]) [ 5, 6, 6, 7, 7, 8 ]
+            ]
+        , describe "groupsOf" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (groupsOf 3 (range 1 10)) [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]
+            ]
+        , describe "groupsOfWithStep" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (groupsOfWithStep 2 1 (range 1 4)) [ [ 1, 2 ], [ 2, 3 ], [ 3, 4 ] ]
+            ]
+        , describe "groupsOfVarying" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal
+                        (groupsOfVarying [ 2, 3, 1 ] [ "a", "b", "c", "d", "e", "f" ])
+                        [ [ "a", "b" ], [ "c", "d", "e" ], [ "f" ] ]
+            , test "" <|
+                \() ->
+                    Expect.equal
+                        (groupsOfVarying [ 2 ] [ "a", "b", "c", "d", "e", "f" ])
+                        [ [ "a", "b" ] ]
+            , test "" <|
+                \() ->
+                    Expect.equal
+                        (groupsOfVarying [ 2, 3, 1, 5, 6 ] [ "a", "b", "c", "d", "e" ])
+                        [ [ "a", "b" ], [ "c", "d", "e" ] ]
+            ]
+        , describe "greedyGroupsOf" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (greedyGroupsOf 3 (range 1 10)) [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ], [ 10 ] ]
+            ]
+        , describe "greedyGroupsOfWithStep" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (greedyGroupsOfWithStep 3 2 (range 1 6)) [ [ 1, 2, 3 ], [ 3, 4, 5 ], [ 5, 6 ] ]
+            ]
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -352,4 +352,48 @@ all =
                 \() ->
                     Expect.equal (greedyGroupsOfWithStep 3 2 (range 1 6)) [ [ 1, 2, 3 ], [ 3, 4, 5 ], [ 5, 6 ] ]
             ]
+        , describe "isPrefixOf"
+            [ fuzz (list int) "[] is prefix to anything" <|
+                \list ->
+                    List.Extra.isPrefixOf [] list
+                        |> Expect.true "Expected [] to be a prefix."
+            , fuzz (list int) "reflexivity" <|
+                \list ->
+                    List.Extra.isPrefixOf list list
+                        |> Expect.true "Expected list to be a prefix of itself."
+            , fuzz2 (list int) (list int) "antisymmetry" <|
+                \listA listB ->
+                    not (List.Extra.isPrefixOf listA listB)
+                        || not (List.Extra.isPrefixOf listB listA)
+                        || listA == listB
+                        |> Expect.true "Expected exactly one to be prefix of the other."
+            , fuzz3 (list int) (list int) (list int) "transitivity" <|
+                \listA listB listC ->
+                    not (List.Extra.isPrefixOf listA listB)
+                        || not (List.Extra.isPrefixOf listB listC)
+                        || List.Extra.isPrefixOf listA listC
+                        |> Expect.true "Expected prefix of prefix to be prefix."
+            ]
+        , describe "isSuffixOf"
+            [ fuzz (list int) "[] is suffix to anything" <|
+                \list ->
+                    List.Extra.isSuffixOf [] list
+                        |> Expect.true "Expected [] to be a suffix."
+            , fuzz (list int) "reflexivity" <|
+                \list ->
+                    List.Extra.isSuffixOf list list
+                        |> Expect.true "Expected list to be a suffix of itself."
+            , fuzz2 (list int) (list int) "antisymmetry" <|
+                \listA listB ->
+                    not (List.Extra.isSuffixOf listA listB)
+                        || not (List.Extra.isSuffixOf listB listA)
+                        || listA == listB
+                        |> Expect.true "Expected exactly one to be suffix of the other."
+            , fuzz3 (list int) (list int) (list int) "transitivity" <|
+                \listA listB listC ->
+                    not (List.Extra.isSuffixOf listA listB)
+                        || not (List.Extra.isSuffixOf listB listC)
+                        || List.Extra.isSuffixOf listA listC
+                        |> Expect.true "Expected suffix of suffix to be suffix."
+            ]
         ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.0.0",
+    "summary": "List.Extra Test Suite",
+    "repository": "https://github.com/elm-community/list-extra.git",
+    "license": "MIT",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
Because `map2` discards extra elements in either of its list parameters, the current implementation functions as "either is prefix of the other", not as "first is prefix of second".

Example:

```elm
isPrefixOf [1, 2] [1, 2, 3] == isPrefixOf [1, 2, 3] [1, 2]
```

This can be fixed by comparing list lengths first.

Caveat: I think fixing this behaviour would constitute a breaking change, as implementations may rely on the symmetry.