### PR TITLE
Rewrite takeWhile so it can be tail-call-optimised

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -251,16 +251,20 @@ minimumBy f ls =
 {-| Take elements in order as long as the predicate evaluates to `True`
 -}
 takeWhile : (a -> Bool) -> List a -> List a
-takeWhile predicate list =
-    case list of
-        [] ->
-            []
+takeWhile predicate =
+    let
+        takeWhileMemo memo list =
+            case list of
+                [] ->
+                    List.reverse memo
 
-        x :: xs ->
-            if (predicate x) then
-                x :: takeWhile predicate xs
-            else
-                []
+                x :: xs ->
+                    if (predicate x) then
+                        takeWhileMemo (x :: memo) xs
+                    else
+                        List.reverse memo
+    in
+        takeWhileMemo []
 
 
 {-| Drop elements in order as long as the predicate evaluates to `True`

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -225,6 +225,11 @@ all =
                 \() ->
                     Expect.equal (dropWhileRight ((<) 5) (range 1 10)) [ 1, 2, 3, 4, 5 ]
             ]
+        , describe "takeWhile" <|
+            [ test "doesn't exceed maximum call stack" <|
+                \() ->
+                    Expect.equal (takeWhile ((>) 19999) (range 1 20000)) (range 1 19998)
+            ]
         , describe "span" <|
             [ test "" <|
                 \() ->


### PR DESCRIPTION
Hi,

takeWhile was crashing on long lists, rewriting it this way allows the elm compiler to use a loop in JS.