### PR TITLE
Add initialize function.

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -27,6 +27,7 @@ module List.Extra
         , removeAt
         , filterNot
         , iterate
+        , initialize
         , intercalate
         , transpose
         , subsequences
@@ -90,7 +91,7 @@ module List.Extra
 @docs foldl1, foldr1, indexedFoldl, indexedFoldr
 
 # Building lists
-@docs scanl1, scanr, scanr1, unfoldr, iterate
+@docs scanl1, scanr, scanr1, unfoldr, iterate, initialize
 
 # Sublists
 @docs splitAt, takeWhileRight, dropWhileRight, span, break, stripPrefix, group, groupWhile, groupWhileTransitively, inits, tails, select, selectSplit
@@ -179,6 +180,23 @@ iterate f x =
 
         Nothing ->
             [ x ]
+
+
+{-| Initialize a list of some length with some function.
+
+`initialize n f` creates a list of length `n` with the element at index `i` initialized to the result of `f i`.
+
+-}
+initialize : Int -> (Int -> a) -> List a
+initialize n f =
+    let
+        step i acc =
+            if i < 0 then
+                acc
+            else
+                step (i - 1) (f i :: acc)
+    in
+        step (n - 1) []
 
 
 {-| Decompose a list into its head and tail. If the list is empty, return `Nothing`. Otherwise, return `Just (x, xs)`, where `x` is head and `xs` is tail.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -197,6 +197,17 @@ all =
                         )
                         [ 5, 4, 3, 2, 1 ]
             ]
+        , describe "initialize" <|
+            [ test "" <|
+                \() ->
+                    Expect.equal (initialize 5 identity) [ 0, 1, 2, 3, 4 ]
+            , test "" <|
+                \() ->
+                    Expect.equal (initialize 5 (\x -> x * 2)) [ 0, 2, 4, 6, 8 ]
+            , test "" <|
+                \() ->
+                    Expect.equal (initialize 1 (always 3)) [ 3 ]
+            ]
         , describe "splitAt" <|
             [ test "" <|
                 \() ->


### PR DESCRIPTION
I was surprised to find out that there is [`initialize`](http://package.elm-lang.org/packages/elm-lang/core/latest/Array#initialize) for `Array`s but not for `List`s, as far as I know. I implemented it starting the computation from the end so it's tail recursive. Let me know your thoughts. 