### PR TITLE
`singleton` is now in core

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.0.1",
+    "version": "6.0.0",
     "summary": "Convenience functions for working with List",
     "repository": "https://github.com/elm-community/list-extra.git",
     "license": "MIT",
@@ -10,7 +10,7 @@
         "List.Extra"
     ],
     "dependencies": {
-        "elm-lang/core": "5.0.0 <= v < 6.0.0"
+        "elm-lang/core": "5.1.0 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
         "List.Extra"
     ],
     "dependencies": {
-        "elm-lang/core": "5.1.0 <= v < 6.0.0"
+        "elm-lang/core": "5.1.1 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -23,7 +23,6 @@ module List.Extra
         , updateIf
         , updateAt
         , updateIfIndex
-        , singleton
         , removeAt
         , filterNot
         , iterate
@@ -81,7 +80,7 @@ module List.Extra
 {-| Convenience functions for working with List
 
 # Basics
-@docs last, init, getAt, (!!), uncons, maximumBy, minimumBy, andMap, andThen, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, replaceIf, setAt, remove, updateIf, updateAt, updateIfIndex, singleton, removeAt, filterNot, swapAt, stableSortWith
+@docs last, init, getAt, (!!), uncons, maximumBy, minimumBy, andMap, andThen, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, replaceIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, filterNot, swapAt, stableSortWith
 
 # List transformations
 @docs intercalate, transpose, subsequences, permutations, interweave
@@ -575,15 +574,6 @@ swapAt index1 index2 l =
                 )
                 (uncons head2)
                 (uncons tail2)
-
-
-{-| Convert a value to a list containing one value.
-
-    singleton 3 == [3]
--}
-singleton : a -> List a
-singleton x =
-    [ x ]
 
 
 {-| Remove the element at an index from a list. If the index is out of range, this returns the original list unchanged. Otherwise, it returns the updated list.


### PR DESCRIPTION
The [latest version of `core`'s `List` already contains `singleton`](http://package.elm-lang.org/packages/elm-lang/core/5.1.0/List#singleton). This causes a naming conflict when trying to do `import List.Extra as List`.