### PR TITLE
Tail call optimize group while transitively

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1069,24 +1069,37 @@ groupWhile eq xs_ =
 
 -}
 groupWhileTransitively : (a -> a -> Bool) -> List a -> List (List a)
-groupWhileTransitively cmp xs_ =
-    case xs_ of
+groupWhileTransitively compare list =
+    groupWhileTransitivelyHelp [] [] compare list
+
+
+groupWhileTransitivelyHelp : List (List a) -> List a -> (a -> a -> Bool) -> List a -> List (List a)
+groupWhileTransitivelyHelp result currentGroup compare list =
+    case list of
         [] ->
-            []
+            List.reverse <|
+                if List.isEmpty currentGroup then
+                    result
+                else
+                    List.reverse (currentGroup :: result)
 
         [ x ] ->
-            [ [ x ] ]
+            List.reverse <|
+                (List.reverse (x :: currentGroup) :: result)
 
-        x :: ((x_ :: _) as xs) ->
-            case groupWhileTransitively cmp xs of
-                (y :: ys) as r ->
-                    if cmp x x_ then
-                        (x :: y) :: ys
-                    else
-                        [ x ] :: r
-
-                [] ->
+        first :: ((second :: _) as rest) ->
+            if compare first second then
+                groupWhileTransitivelyHelp
+                    result
+                    (first :: currentGroup)
+                    compare
+                    rest
+            else
+                groupWhileTransitivelyHelp
+                    (List.reverse (first :: currentGroup) :: result)
                     []
+                    compare
+                    rest
 
 
 {-| Return all initial segments of a list, from shortest to longest, empty list first, the list itself last.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -295,7 +295,17 @@ all =
                         [ [ 1, 2, 3, 2, 4 ], [ 1, 3, 2 ], [ 1 ] ]
             ]
         , describe "groupWhileTransitively" <|
-            [ test "" <|
+            [ test "an empty list" <|
+                \() ->
+                    Expect.equal
+                        (groupWhileTransitively (<) [])
+                        []
+            , test "a single item" <|
+                \() ->
+                    Expect.equal
+                        (groupWhileTransitively (<) [ 1 ])
+                        [ [ 1 ] ]
+            , test "a standard working case" <|
                 \() ->
                     Expect.equal
                         (groupWhileTransitively (<) [ 1, 2, 3, 2, 4, 1, 3, 2, 1 ])


### PR DESCRIPTION
After experience stack limiting, I noticed current implementation of `groupWhileTransitively` doesn't take advantage of tail call optimization.

This PR:
* Adds test cases to `groupWhileTransitively`
* Clarifies variable naming
* Changes to tail call optimized version


Compare:

## Old compiled code:
```js
var _elm_community$list_extra$List_Extra$groupWhileTransitively = F2(
	function (cmp, xs_) {
		var _p13 = xs_;
		if (_p13.ctor === '[]') {
			return {ctor: '[]'};
		} else {
			if (_p13._1.ctor === '[]') {
				return {
					ctor: '::',
					_0: {
						ctor: '::',
						_0: _p13._0,
						_1: {ctor: '[]'}
					},
					_1: {ctor: '[]'}
				};
			} else {
				var _p15 = _p13._0;
				var _p14 = A2(_elm_community$list_extra$List_Extra$groupWhileTransitively, cmp, _p13._1);
				if (_p14.ctor === '::') {
					return A2(cmp, _p15, _p13._1._0) ? {
						ctor: '::',
						_0: {ctor: '::', _0: _p15, _1: _p14._0},
						_1: _p14._1
					} : {
						ctor: '::',
						_0: {
							ctor: '::',
							_0: _p15,
							_1: {ctor: '[]'}
						},
						_1: _p14
					};
				} else {
					return {ctor: '[]'};
				}
			}
		}
	});


```

## New compiled code

```js
var _elm_community$list_extra$List_Extra$groupWhileTransitively = F2(
	function (compare, list) {
		return A4(
			_elm_community$list_extra$List_Extra$groupWhileTransitivelyHelp,
			{ctor: '[]'},
			{ctor: '[]'},
			compare,
			list);
	});
var _elm_community$list_extra$List_Extra$groupWhileTransitivelyHelp = F4(
	function (result, currentGroup, compare, list) {
		groupWhileTransitivelyHelp:
		while (true) {
			var _p13 = list;
			if (_p13.ctor === '[]') {
				return _elm_lang$core$List$reverse(
					_elm_lang$core$List$isEmpty(currentGroup) ? result : _elm_lang$core$List$reverse(
						{ctor: '::', _0: currentGroup, _1: result}));
			} else {
				if (_p13._1.ctor === '[]') {
					return _elm_lang$core$List$reverse(
						{
							ctor: '::',
							_0: _elm_lang$core$List$reverse(
								{ctor: '::', _0: _p13._0, _1: currentGroup}),
							_1: result
						});
				} else {
					var _p15 = _p13._1;
					var _p14 = _p13._0;
					if (A2(compare, _p14, _p13._1._0)) {
						var _v7 = result,
							_v8 = {ctor: '::', _0: _p14, _1: currentGroup},
							_v9 = compare,
							_v10 = _p15;
						result = _v7;
						currentGroup = _v8;
						compare = _v9;
						list = _v10;
						continue groupWhileTransitivelyHelp;
					} else {
						var _v11 = {
							ctor: '::',
							_0: _elm_lang$core$List$reverse(
								{ctor: '::', _0: _p14, _1: currentGroup}),
							_1: result
						},
							_v12 = {ctor: '[]'},
							_v13 = compare,
							_v14 = _p15;
						result = _v11;
						currentGroup = _v12;
						compare = _v13;
						list = _v14;
						continue groupWhileTransitivelyHelp;
					}
				}
			}
		}
	});
```


