### PR TITLE
Add reverseMap

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -9,6 +9,7 @@ module List.Extra
         , maximumBy
         , andMap
         , andThen
+        , reverseMap
         , takeWhile
         , dropWhile
         , unique
@@ -83,7 +84,7 @@ module List.Extra
 
 # Basics
 
-@docs last, init, getAt, (!!), uncons, maximumBy, minimumBy, andMap, andThen, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, replaceIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, filterNot, swapAt, stableSortWith
+@docs last, init, getAt, (!!), uncons, maximumBy, minimumBy, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, replaceIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, filterNot, swapAt, stableSortWith
 
 
 # List transformations
@@ -397,6 +398,17 @@ Advanced functional programmers will recognize this as the implementation of bin
 andThen : (a -> List b) -> List a -> List b
 andThen =
     concatMap
+
+
+{-| `reverseMap f xs` gives the same result as `List.reverse (List.map f xs)`,
+but is tail-recursive and slightly more efficient.
+
+    reverseMap sqrt [1,4,9] == [3,2,1]
+
+-}
+reverseMap : (a -> b) -> List a -> List b
+reverseMap f xs =
+    foldl (\x acc -> f x :: acc) [] xs
 
 
 {-| Negation of `member`.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -32,6 +32,11 @@ all =
                         )
                         [ 9, 7, 9 ]
             ]
+        , describe "reverseMap" <|
+            [ test "maps and reverses" <|
+                \() ->
+                    Expect.equal (reverseMap sqrt [ 1, 4, 9 ]) [ 3, 2, 1 ]
+            ]
         , describe "notMember" <|
             [ test "disconfirms member" <|
                 \() ->


### PR DESCRIPTION
`reverseMap` is a pretty handy function for efficiently mapping and reversing a `List`. It is inspired by OCaml's [`List.rev_map`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/List.html#VALrev_map) function.

An example use case is if you have a list of events in chronological order, and you would like to display them in reverse chronological order (like on a résumé or a todo list). Using `reverseMap`, you can convert each event into an `Html msg` and reverse the order of the events all in a single pass.