### PR TITLE
Clarify docs for groupsOfWithStep

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1243,7 +1243,9 @@ lift4 f la lb lc ld =
     la |> andThen (\a -> lb |> andThen (\b -> lc |> andThen (\c -> ld |> andThen (\d -> [ f a b c d ]))))
 
 
-{-| Split list into groups of size given by the first argument.
+{-| Split list into groups of length `size`. If there are not enough elements
+to completely fill the last group, it will not be included. This is equivalent
+to calling `groupsOfWithStep` with the same `size` and `step`.
 
     groupsOf 3 (range 1 10) == [[1,2,3],[4,5,6],[7,8,9]]
 
@@ -1253,10 +1255,19 @@ groupsOf size xs =
     groupsOfWithStep size size xs
 
 
-{-| Split list into groups of size given by the first argument. After each group, drop a number of elements given by the second argument before starting the next group.
+{-| Split list into groups of length `size` at offsets `step` apart. If there
+are not enough elements to completely fill the last group, it will not be
+included. (See `greedyGroupsOfWithStep` if you would like the last group to be
+included regardless.)
 
-    groupsOfWithStep 2 1 (range 1 4) == [[1,2],[2,3],[3,4]]
+    groupsOfWithStep 4 4 (range 1 10) == [[1,2,3,4],[5,6,7,8]]
+    groupsOfWithStep 3 1 (range 1 5) == [[1,2,3],[2,3,4],[3,4,5]]
+    groupsOfWithStep 3 6 (range 1 20) == [[1,2,3],[7,8,9],[13,14,15]]
 
+If `step == size`, every element (except for perhaps the last few due to the
+non-greedy behavior) will appear in exactly one group. If `step < size`, there
+will be an overlap between groups. If `step > size`, some elements will be
+skipped and not appear in any groups.
 -}
 groupsOfWithStep : Int -> Int -> List a -> List (List a)
 groupsOfWithStep size step xs =
@@ -1305,7 +1316,10 @@ groupsOfVarying_ listOflengths list accu =
             List.reverse accu
 
 
-{-| Split list into groups of size given by the first argument "greedily" (don't throw the group away if not long enough).
+{-| Greedily split list into groups of length `size`. The last group of
+elements will be included regardless of whether there are enough elements in
+the list to completely fill it. This is equivalent to calling
+`greedyGroupsOfWithStep` with the same `size` and `step`.
 
     greedyGroupsOf 3 (range 1 10) == [[1,2,3],[4,5,6],[7,8,9],[10]]
 
@@ -1315,10 +1329,18 @@ greedyGroupsOf size xs =
     greedyGroupsOfWithStep size size xs
 
 
-{-| Split list into groups of size given by the first argument "greedily" (don't throw the group away if not long enough). After each group, drop a number of elements given by the second argumet before starting the next group.
+{-| Greedily split list into groups of length `size` at offsets `step` apart.
+The last group of elements will be included regardless of whether there are
+enough elements in the list to completely fill it. (See `groupsOfWithStep`
+for the non-greedy version of this function).
 
+    greedyGroupsOfWithStep 4 4 (range 1 10) == [[1,2,3,4],[5,6,7,8],[9,10]]
     greedyGroupsOfWithStep 3 2 (range 1 6) == [[1,2,3],[3,4,5],[5,6]]
+    greedyGroupsOfWithStep 3 6 (range 1 20) == [[1,2,3],[7,8,9],[13,14,15],[19,20]]
 
+If `step == size`, every element will appear in exactly one group. If
+`step < size`, there will be an overlap between groups. If `step > size`, some
+elements will be skipped and not appear in any groups.
 -}
 greedyGroupsOfWithStep : Int -> Int -> List a -> List (List a)
 greedyGroupsOfWithStep size step xs =

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -331,12 +331,22 @@ all =
         , describe "groupsOf" <|
             [ test "" <|
                 \() ->
-                    Expect.equal (groupsOf 3 (range 1 10)) [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]
+                    Expect.equal (groupsOf 3 (range 1 10))
+                        [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]
             ]
         , describe "groupsOfWithStep" <|
-            [ test "" <|
+            [ test "step == size" <|
                 \() ->
-                    Expect.equal (groupsOfWithStep 2 1 (range 1 4)) [ [ 1, 2 ], [ 2, 3 ], [ 3, 4 ] ]
+                    Expect.equal (groupsOfWithStep 4 4 (range 1 10))
+                        [ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ] ]
+            , test "step < size" <|
+                \() ->
+                    Expect.equal (groupsOfWithStep 3 1 (range 1 5))
+                        [ [ 1, 2, 3 ], [ 2, 3, 4 ], [ 3, 4, 5 ] ]
+            , test "step > size" <|
+                \() ->
+                    Expect.equal (groupsOfWithStep 3 6 (range 1 20))
+                        [ [ 1, 2, 3 ], [ 7, 8, 9 ], [ 13, 14, 15 ] ]
             ]
         , describe "groupsOfVarying" <|
             [ test "" <|
@@ -358,12 +368,22 @@ all =
         , describe "greedyGroupsOf" <|
             [ test "" <|
                 \() ->
-                    Expect.equal (greedyGroupsOf 3 (range 1 10)) [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ], [ 10 ] ]
+                    Expect.equal (greedyGroupsOf 3 (range 1 10))
+                        [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ], [ 10 ] ]
             ]
         , describe "greedyGroupsOfWithStep" <|
-            [ test "" <|
+            [ test "step == size" <|
                 \() ->
-                    Expect.equal (greedyGroupsOfWithStep 3 2 (range 1 6)) [ [ 1, 2, 3 ], [ 3, 4, 5 ], [ 5, 6 ] ]
+                    Expect.equal (greedyGroupsOfWithStep 4 4 (range 1 10))
+                        [ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10 ] ]
+            , test "step < size" <|
+                \() ->
+                    Expect.equal (greedyGroupsOfWithStep 3 2 (range 1 6))
+                        [ [ 1, 2, 3 ], [ 3, 4, 5 ], [ 5, 6 ] ]
+            , test "step > size" <|
+                \() ->
+                    Expect.equal (greedyGroupsOfWithStep 3 6 (range 1 20))
+                        [ [ 1, 2, 3 ], [ 7, 8, 9 ], [ 13, 14, 15 ], [ 19, 20 ] ]
             ]
         , describe "isPrefixOf"
             [ fuzz (list int) "[] is prefix to anything" <|


### PR DESCRIPTION
`groupsOfWithStep` and `greedyGroupsOfWithStep` have misleading/incorrect documentation. This pull request fixes the documentation for those functions to reflect the author's intent. Closes #53.