### PR TITLE
Fix Travis Builds By Speeding Them Up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,36 @@
+sudo: false
+
 language: node_js
-node_js:
-  - "5"
+node_js: node
+
+cache:
+  directories:
+    - elm-stuff/build-artifacts
+    - elm-stuff/packages
+    - sysconfcpus
+
+os:
+  - linux
+
+before_install:
+  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+
 install:
-  - npm install -g elm
-  - npm install -g elm-test
-  - elm-package install -y
-  - pushd tests && elm-package install -y && popd
+  - npm install -g elm elm-test
+  - elm package install --yes
+  - |
+    if [ ! -d "$TRAVIS_BUILD_DIR/sysconfcpus/bin" ];
+    then
+      git clone https://github.com/obmarg/libsysconfcpus.git;
+      cd libsysconfcpus;
+      ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
+      make && make install;
+      cd ..;
+    fi
+
+before_script:
+  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make --yes src/List/Extra.elm
+  - cd tests && $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make --yes Tests.elm ../src/List/Extra.elm && cd ..
+
 script:
-  - elm-test
+  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-test


### PR DESCRIPTION
Travis builds were failing with the release of elm-test 0.18.5 because they
produced no output for over 10 minutes.

This fixes the issue by using the sample Travis config from the node
test runner's README, which uses sysconfcpus to fix the amount of CPUs
that Elm believes the system has.

This brings Travis builds from 11+ minutes down to 2 minutes.