### PR TITLE
Optimize isSubsequenceOf

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1251,7 +1251,12 @@ isInfixOf infix xs =
     any (isPrefixOf infix) (tails xs)
 
 
-{-| Take 2 lists and return True, if the first list is a subsequence of the second list.
+{-| Return True if all the elements of the first list occur, in order, in the
+second. The elements do not have to occur consecutively.
+
+    isSubsequenceOf ["E", "l", "m"] ["E", "a", "t", " ", "l", "i", "m", "e", "s"] == True
+    isSubsequenceOf ["E", "l", "m"] ["E", "m", "a", "i", "l"] == False
+
 -}
 isSubsequenceOf : List a -> List a -> Bool
 isSubsequenceOf subseq list =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1254,8 +1254,19 @@ isInfixOf infix xs =
 {-| Take 2 lists and return True, if the first list is a subsequence of the second list.
 -}
 isSubsequenceOf : List a -> List a -> Bool
-isSubsequenceOf subseq xs =
-    member subseq (subsequences xs)
+isSubsequenceOf subseq list =
+    case ( subseq, list ) of
+        ( [], _ ) ->
+            True
+
+        ( _, [] ) ->
+            False
+
+        ( x :: xs, y :: ys ) ->
+            if x == y then
+                isSubsequenceOf xs ys
+            else
+                isSubsequenceOf subseq ys
 
 
 {-| Take 2 lists and return True, if the first list is a permutation of the second list.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -349,6 +349,17 @@ all =
                 \() ->
                     Expect.equal (selectSplit [ 1, 2, 3 ]) [ ( [], 1, [ 2, 3 ] ), ( [ 1 ], 2, [ 3 ] ), ( [ 1, 2 ], 3, [] ) ]
             ]
+        , describe "isSubsequenceOf" <|
+            [ test "success" <|
+                \() ->
+                    Expect.true "Elm is a subsequence of Eat lime" (isSubsequenceOf [ "E", "l", "m" ] [ "E", "a", "t", " ", "l", "i", "m", "e", "s" ])
+            , test "failure" <|
+                \() ->
+                    Expect.false "Elm is not a subsequence of Email" (isSubsequenceOf [ "E", "l", "m" ] [ "E", "m", "a", "i", "l" ])
+            , test "success at last element" <|
+                \() ->
+                    Expect.true "[] should be a subsequence of []" (isSubsequenceOf [ 1, 3 ] [ 1, 2, 3 ])
+            ]
         , describe "lift2" <|
             [ test "produces all combinations of addition" <|
                 \() ->


### PR DESCRIPTION
This greatly improves the performance of `isSubsequenceOf`. The current implementation was crashing my browser tab for lists longer than 25-30 elements. Additionally, for smaller Lists of 10-20 elements, my [benchmarks](https://ellie-app.com/3y4xhPZVLkfa1/3) are showing a greater than 40% improvement in runtime.