### PR TITLE
Optimize isInfixOf

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1244,7 +1244,13 @@ isSuffixOf suffix xs =
     isPrefixOf (reverse suffix) (reverse xs)
 
 
-{-| Take 2 lists and return True, if the first list is an infix of the second list.
+{-| Return True if all the elements of the first list occur in-order and
+consecutively anywhere within the second.
+
+    isInfixOf [5, 7, 11] [2, 3, 5, 7, 11, 13] == True
+    isInfixOf [5, 7, 13] [2, 3, 5, 7, 11, 13] == False
+    isInfixOf [3, 5, 2] [2, 3, 5, 7, 11, 13] == False
+
 -}
 isInfixOf : List a -> List a -> Bool
 isInfixOf infixList list =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1247,8 +1247,26 @@ isSuffixOf suffix xs =
 {-| Take 2 lists and return True, if the first list is an infix of the second list.
 -}
 isInfixOf : List a -> List a -> Bool
-isInfixOf infix xs =
-    any (isPrefixOf infix) (tails xs)
+isInfixOf infixList list =
+    case infixList of
+        [] ->
+            True
+
+        x :: xs ->
+            isInfixOfHelp x xs list
+
+
+isInfixOfHelp : a -> List a -> List a -> Bool
+isInfixOfHelp infixHead infixTail list =
+    case list of
+        [] ->
+            False
+
+        x :: xs ->
+            if x == infixHead then
+                isPrefixOf infixTail xs
+            else
+                isInfixOfHelp infixHead infixTail xs
 
 
 {-| Take 2 lists and return True, if the first list is a subsequence of the second list.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -457,6 +457,17 @@ all =
                         || List.Extra.isSuffixOf listA listC
                         |> Expect.true "Expected suffix of suffix to be suffix."
             ]
+        , describe "isInfixOf"
+            [ test "success" <|
+                \() ->
+                    Expect.true "5, 7, 11 is infix of 2, 3, 5, 7, 11, 13" (isInfixOf [ 5, 7, 11 ] [ 2, 3, 5, 7, 11, 13 ])
+            , test "not consecutive" <|
+                \() ->
+                    Expect.false "5, 7, 13 is not infix of 2, 3, 5, 7, 11, 13" (isInfixOf [ 5, 7, 13 ] [ 2, 3, 5, 7, 11, 13 ])
+            , test "not in-order" <|
+                \() ->
+                    Expect.false "3, 5, 2 is not infix of 2, 3, 5, 7, 11, 13" (isInfixOf [ 3, 5, 2 ] [ 2, 3, 5, 7, 11, 13 ])
+            ]
         , describe "swapAt"
             [ test "negative index as first argument returns the original list" <|
                 \() ->


### PR DESCRIPTION
Improves the performance of `isInfixOf`. My [benchmarks](https://ellie-app.com/3ybf5fnL6Vja1/1) are showing that this version decreases the runtime of the current version by 60-70%.