### PR TITLE
Optimize interweave

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -817,6 +817,7 @@ If one list runs out of items, append the items from the remaining list.
 
     interweave [1,3] [2,4] == [1,2,3,4]
     interweave [1,3,5,7] [2,4] == [1,2,3,4,5,7]
+    interweave [4,9,16] [2,3,5,7] == [4,2,9,3,16,5,7]
 
 -}
 interweave : List a -> List a -> List a

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -820,21 +820,26 @@ If one list runs out of items, append the items from the remaining list.
 
 -}
 interweave : List a -> List a -> List a
-interweave l1 l2 =
-    interweaveHelp l1 l2 []
+interweave =
+    interweaveHelp []
 
 
 interweaveHelp : List a -> List a -> List a -> List a
-interweaveHelp l1 l2 acc =
-    case ( l1, l2 ) of
+interweaveHelp acc list1 list2 =
+    case ( list1, list2 ) of
         ( x :: xs, y :: ys ) ->
-            interweaveHelp xs ys <| acc ++ [ x, y ]
+            interweaveHelp (y :: x :: acc) xs ys
 
-        ( x, [] ) ->
-            acc ++ x
+        ( [], _ ) ->
+            reverseAppend acc list2
 
-        ( [], y ) ->
-            acc ++ y
+        ( _, [] ) ->
+            reverseAppend acc list1
+
+
+reverseAppend : List a -> List a -> List a
+reverseAppend list1 list2 =
+    List.foldl (::) list2 list1
 
 
 {-| Variant of `foldl` that has no starting value argument and treats the head of the list as its starting value. If the list is empty, return `Nothing`.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -131,9 +131,12 @@ all =
             [ test "interweaves lists of equal length" <|
                 \() ->
                     Expect.equal (interweave [ 1, 3 ] [ 2, 4 ]) [ 1, 2, 3, 4 ]
-            , test "appends remaining members of longer list" <|
+            , test "appends remaining members of first list, if longer" <|
                 \() ->
                     Expect.equal (interweave [ 1, 3, 5, 7 ] [ 2, 4 ]) [ 1, 2, 3, 4, 5, 7 ]
+            , test "appends remaining members of second list, if longer" <|
+                \() ->
+                    Expect.equal (interweave [ 4, 9, 16 ] [ 2, 3, 5, 7 ]) [ 4, 2, 9, 3, 16, 5, 7 ]
             ]
         , describe "foldl1" <|
             [ test "computes maximum" <|


### PR DESCRIPTION
[Benchmarks](https://ellie-app.com/3BHKgSCmGBga1/4) are showing a significant improvement in runtime, particularly on larger lists. For cases where the length of the shorter list is around 5 elements, there is a negligible degradation of approximately 3% over the current implementation. For cases of 50 elements, there is an improvement of over 85% over the current implementation. For cases of 1k+ elements, there are improvements of around 99% (not bad, if I daresay 😄).