### PR TITLE
Add count

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -67,6 +67,7 @@ module List.Extra
         , elemIndices
         , findIndex
         , findIndices
+        , count
         , zip
         , zip3
         , zip4
@@ -116,7 +117,7 @@ module List.Extra
 
 # Searching
 
-@docs notMember, find, elemIndex, elemIndices, findIndex, findIndices
+@docs notMember, find, elemIndex, elemIndices, findIndex, findIndices, count
 
 
 # Zipping
@@ -526,6 +527,25 @@ findIndices predicate =
                 acc
     in
         indexedFoldr consIndexIf []
+
+
+{-| Returns the number of elements in a list that satisfy a given predicate.
+Equivalent to `List.length (List.filter pred list)` but more efficient.
+
+    count (\n -> n % 2 == 1) [1,2,3,4,5,6,7] == 4
+    count ((==) "yeah") ["She","loves","you","yeah","yeah","yeah"] == 3
+
+-}
+count : (a -> Bool) -> List a -> Int
+count predicate =
+    List.foldl
+        (\x acc ->
+            if predicate x then
+                acc + 1
+            else
+                acc
+        )
+        0
 
 
 {-| Replace all values that satisfy a predicate with a replacement value.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -94,6 +94,14 @@ all =
                 \() ->
                     Expect.equal (findIndices (\x -> x % 2 == 0) [ 1, 2, 4 ]) [ 1, 2 ]
             ]
+        , describe "count" <|
+            [ test "isOdd predicate" <|
+                \() ->
+                    Expect.equal (count (\n -> n % 2 == 1) [ 1, 2, 3, 4, 5, 6, 7 ]) 4
+            , test "equal predicate" <|
+                \() ->
+                    Expect.equal (count ((==) "yeah") [ "She", "loves", "you", "yeah", "yeah", "yeah" ]) 3
+            ]
         , describe "intercalate" <|
             [ test "computes example" <|
                 \() ->


### PR DESCRIPTION
`count` is a simple but useful function for checking how many things in a list satisfy some predicate. It is great for when you don't care about the particulars of those things but only their quantity. An example of a good real-world use case is if you are accepting text input from the user and you want to know how many of the words/sentences they used have a particular property.

Suppose we give our students an activity to make complex sentences. A parameter that we might use to check a sentence is seeing if it contains more than one clause, which we can approximate by checking if it contains a `,` character and is adequately long. In order to determine if a student is successful, we simply want to know how many of their sentences satisfy our complexity rule. [We can easily do this using `count`](https://ellie-app.com/3Gm3S9xpXMXa1/0)!