### PR TITLE
Minor updates to docstrings, clarification for `groupWhile`

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1254,7 +1254,7 @@ selectSplit xs =
             ( [], x, xs ) :: map (\( lys, y, rys ) -> ( x :: lys, y, rys )) (selectSplit xs)
 
 
-{-| Take 2 lists and return True, if the first list is the prefix of the second list.
+{-| Take two lists and return `True`, if the first list is the prefix of the second list.
 -}
 isPrefixOf : List a -> List a -> Bool
 isPrefixOf prefix xs =
@@ -1269,7 +1269,7 @@ isPrefixOf prefix xs =
             p == x && isPrefixOf ps xs
 
 
-{-| Take 2 lists and return True, if the first list is the suffix of the second list.
+{-| Take two lists and return `True`, if the first list is the suffix of the second list.
 -}
 isSuffixOf : List a -> List a -> Bool
 isSuffixOf suffix xs =
@@ -1330,7 +1330,7 @@ isSubsequenceOf subseq list =
                 isSubsequenceOf subseq ys
 
 
-{-| Take 2 lists and return True, if the first list is a permutation of the second list.
+{-| Take two lists and return `True`, if the first list is a permutation of the second list.
 -}
 isPermutationOf : List a -> List a -> Bool
 isPermutationOf permut xs =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1130,11 +1130,15 @@ group =
 
     groupWhile (\x y -> first x == first y) [(0,'a'),(0,'b'),(1,'c'),(1,'d')] == [[(0,'a'),(0,'b')],[(1,'c'),(1,'d')]]
 
-The equality test should be an equivalent relationship, i.e. it should have the properties of reflexivity, symmetry, and transitivity. For non-equivalent relations it gives non-intuitive behavior:
+The equality test should be an [equivalence relation](https://en.wikipedia.org/wiki/Equivalence_relation), i.e. it should have the properties:
 
-    groupWhile (<) [1,2,3,2,4,1,3,2,1] == [[1,2,3,2,4],[1,3,2],[1]]
+  - Reflexivity - Testing an object against itself returns `True`.
+  - Symmetry - Testing two objects should give the same result regardless of the order they are passed.
+  - Transitivity - If the test on a first object and a second object results in `True`, and further if the test on that second object and a third also results in `True`, then the test should result in `True` when the first and third objects are passed.
 
-For grouping elements with a comparison test, which must only hold the property of transitivity, see `groupWhileTransitively`.
+For non-equivalent relations `groupWhile` has non-intuitive behavior. For example, inequality comparisons like `(<)` are not equivalence relations, so do _not_ write `groupWhile (<) [1,3,5,2,4]`, as it will give an unexpected answer.
+
+For grouping elements with a comparison test which is merely transitive, such as `(<)` or `(<=)`, see `groupWhileTransitively`.
 
 -}
 groupWhile : (a -> a -> Bool) -> List a -> List (List a)


### PR DESCRIPTION
There was a minor typo calling the test for `groupWhile` an "equivalent relationship". I changed it to "equivalence relation" and wrote out a bit more explicitly for programmers what that means. 

I threw in a few minor grammatical changes.