### PR TITLE
uniqueHelp: accumulator based implementation, call stack size safe

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -339,14 +339,14 @@ dropWhile predicate list =
 -}
 unique : List comparable -> List comparable
 unique list =
-    uniqueHelp identity Set.empty list
+    uniqueHelp identity Set.empty list []
 
 
 {-| Drop duplicates where what is considered to be a duplicate is the result of first applying the supplied function to the elements of the list.
 -}
 uniqueBy : (a -> comparable) -> List a -> List a
 uniqueBy f list =
-    uniqueHelp f Set.empty list
+    uniqueHelp f Set.empty list []
 
 
 {-| Indicate if list has duplicate values.
@@ -366,11 +366,11 @@ allDifferentBy f list =
     List.length list == List.length (uniqueBy f list)
 
 
-uniqueHelp : (a -> comparable) -> Set comparable -> List a -> List a
-uniqueHelp f existing remaining =
+uniqueHelp : (a -> comparable) -> Set comparable -> List a -> List a -> List a
+uniqueHelp f existing remaining accumulator =
     case remaining of
         [] ->
-            []
+            List.reverse accumulator
 
         first :: rest ->
             let
@@ -378,9 +378,9 @@ uniqueHelp f existing remaining =
                     f first
             in
                 if Set.member computedFirst existing then
-                    uniqueHelp f existing rest
+                    uniqueHelp f existing rest accumulator
                 else
-                    first :: uniqueHelp f (Set.insert computedFirst existing) rest
+                    uniqueHelp f (Set.insert computedFirst existing) rest (first :: accumulator)
 
 
 {-| Map functions taking multiple arguments over multiple lists. Each list should be of the same length.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -15,6 +15,9 @@ all =
             [ test "removes duplicates" <|
                 \() ->
                     Expect.equal (List.Extra.unique [ 0, 1, 1, 0, 1 ]) [ 0, 1 ]
+            , test "preserves list order" <|
+                \() ->
+                    Expect.equal (List.Extra.unique [ 3, 3, 2, 1, 1, 0 ]) [ 3, 2, 1, 0 ]
             ]
         , describe "allDifferent" <|
             [ test "detects duplicates" <|
@@ -219,7 +222,7 @@ all =
                                     else
                                         3 * n + 1
                     in
-                        Expect.equal (iterate collatz 13) [13,40,20,10,5,16,8,4,2,1]
+                        Expect.equal (iterate collatz 13) [ 13, 40, 20, 10, 5, 16, 8, 4, 2, 1 ]
             ]
         , describe "initialize" <|
             [ test "creates a list starting from zero" <|


### PR DESCRIPTION
Modified the `uniqueHelp` implementation to use an accumulator. This prevents the function to crash on very large lists. I added a test to make sure list order is preserved correctly.

Fixes #61 