### PR TITLE
Add cycle

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -29,6 +29,7 @@ module List.Extra
         , filterNot
         , iterate
         , initialize
+        , cycle
         , intercalate
         , transpose
         , subsequences
@@ -102,7 +103,7 @@ module List.Extra
 
 # Building lists
 
-@docs scanl1, scanr, scanr1, unfoldr, iterate, initialize
+@docs scanl1, scanr, scanr1, unfoldr, iterate, initialize, cycle
 
 
 # Sublists
@@ -229,6 +230,42 @@ initialize n f =
                 step (i - 1) (f i :: acc)
     in
         step (n - 1) []
+
+
+{-| Creates a list of the given length whose elements are obtained by cycling
+through the elements of the given list. If the given list is empty, the
+resulting list will be empty.
+
+    cycle 6 [ 4, 7, 8 ] == [ 4, 7, 8, 4, 7, 8 ]
+    cycle 4 [ 'a', 'b', 'c' ] == [ 'a', 'b', 'c', 'a' ]
+    cycle 9001 [] == []
+    cycle 2 [ 1, 2, 3, 4, 5 ] == [ 1, 2 ]
+
+-}
+cycle : Int -> List a -> List a
+cycle len list =
+    let
+        cycleLength =
+            List.length list
+    in
+        if cycleLength == 0 || cycleLength == len then
+            list
+        else if cycleLength < len then
+            List.reverse
+                (reverseAppend
+                    (List.take (rem len cycleLength) list)
+                    (cycleHelp [] (len // cycleLength) list)
+                )
+        else
+            List.take len list
+
+
+cycleHelp : List a -> Int -> List a -> List a
+cycleHelp acc n list =
+    if n > 0 then
+        cycleHelp (reverseAppend list acc) (n - 1) list
+    else
+        acc
 
 
 {-| Decompose a list into its head and tail. If the list is empty, return `Nothing`. Otherwise, return `Just (x, xs)`, where `x` is head and `xs` is tail.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -243,6 +243,23 @@ all =
                 \() ->
                     Expect.equal (initialize 1 (always 3)) [ 3 ]
             ]
+        , describe "cycle" <|
+            [ test "same length" <|
+                \() ->
+                    Expect.equal (cycle 3 [ 4, 7, 8 ]) [ 4, 7, 8 ]
+            , test "multiple of length" <|
+                \() ->
+                    Expect.equal (cycle 6 [ 4, 7, 8 ]) [ 4, 7, 8, 4, 7, 8 ]
+            , test "partial cycle" <|
+                \() ->
+                    Expect.equal (cycle 4 [ 'a', 'b', 'c' ]) [ 'a', 'b', 'c', 'a' ]
+            , test "empty list" <|
+                \() ->
+                    Expect.equal (cycle 9001 []) []
+            , test "resulting length smaller than cycle length" <|
+                \() ->
+                    Expect.equal (cycle 2 [ 1, 2, 3, 4, 5 ]) [ 1, 2 ]
+            ]
         , describe "splitAt" <|
             [ test "splits a list in the middle" <|
                 \() ->


### PR DESCRIPTION
Related to #72. After some discussion in that PR, it seemed as though the consensus was to make `cycle` accept the length of the resulting list (as opposed to e.g. the number of times the given list should be cycled). This PR contains what I believe to be a relatively fast TCO implementation of `cycle` with the desired behavior (since this would be the initial implementation, there isn't really anything to benchmark it against).