### PR TITLE
Make transpose call stack size safe

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -813,28 +813,18 @@ If some rows are shorter than the following rows, their elements are skipped:
 
 -}
 transpose : List (List a) -> List (List a)
-transpose =
-    transposeHelp []
+transpose listOfLists =
+    List.foldr (List.map2 (::)) (List.repeat (rowsLength listOfLists) []) listOfLists
 
 
-transposeHelp : List (List a) -> List (List a) -> List (List a)
-transposeHelp acc ll =
-    case ll of
+rowsLength : List (List a) -> Int
+rowsLength listOfLists =
+    case listOfLists of
         [] ->
-            acc
+            0
 
-        [] :: xss ->
-            transposeHelp acc xss
-
-        (x :: xs) :: xss ->
-            let
-                heads =
-                    filterMap head xss
-
-                tails =
-                    filterMap tail xss
-            in
-                transposeHelp (acc ++ [ x :: heads ]) (xs :: tails)
+        x :: _ ->
+            List.length x
 
 
 {-| Return the list of all subsequences of a list.

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -813,13 +813,18 @@ If some rows are shorter than the following rows, their elements are skipped:
 
 -}
 transpose : List (List a) -> List (List a)
-transpose ll =
+transpose =
+    transposeHelp []
+
+
+transposeHelp : List (List a) -> List (List a) -> List (List a)
+transposeHelp acc ll =
     case ll of
         [] ->
-            []
+            acc
 
         [] :: xss ->
-            transpose xss
+            transposeHelp acc xss
 
         (x :: xs) :: xss ->
             let
@@ -829,7 +834,7 @@ transpose ll =
                 tails =
                     filterMap tail xss
             in
-                (x :: heads) :: transpose (xs :: tails)
+                transposeHelp (acc ++ [ x :: heads ]) (xs :: tails)
 
 
 {-| Return the list of all subsequences of a list.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -123,6 +123,11 @@ all =
                     Expect.equal
                         (transpose [ [ 10, 11 ], [ 20 ], [], [ 30, 31, 32 ] ])
                         [ [ 10, 20, 30 ], [ 11, 31 ], [ 32 ] ]
+            , test "transposes large lists" <|
+                \() ->
+                    Expect.equal
+                        (transpose [ List.repeat 10000 1 ])
+                        (List.repeat 10000 [ 1 ])
             ]
         , describe "subsequences" <|
             [ test "computes subsequences" <|

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -118,11 +118,11 @@ all =
                     Expect.equal
                         (transpose [ [ 1, 2, 3 ], [ 4, 5, 6 ] ])
                         [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
-            , test "short rows are skipped" <|
+            , test "truncate the matrix to the shortest row size" <|
                 \() ->
                     Expect.equal
-                        (transpose [ [ 10, 11 ], [ 20 ], [], [ 30, 31, 32 ] ])
-                        [ [ 10, 20, 30 ], [ 11, 31 ], [ 32 ] ]
+                        (transpose [ [ 10, 11 ], [ 20 ], [ 30, 31, 32 ] ])
+                        [ [ 10, 20, 30 ] ]
             , test "transposes large lists" <|
                 \() ->
                     Expect.equal


### PR DESCRIPTION
With 10000 elements the transpose function start giving `Maximum call stack size exceeded`

https://ellie-app.com/8qhGRQbVQa1/0