### PR TITLE
Add cartesianProduct function

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -34,6 +34,7 @@ module List.Extra
         , subsequences
         , permutations
         , interweave
+        , cartesianProduct
         , foldl1
         , foldr1
         , indexedFoldl
@@ -92,7 +93,7 @@ module List.Extra
 
 # List transformations
 
-@docs intercalate, transpose, subsequences, permutations, interweave
+@docs intercalate, transpose, subsequences, permutations, interweave, cartesianProduct
 
 
 # Folds
@@ -866,6 +867,27 @@ interweaveHelp acc list1 list2 =
 
         ( _, [] ) ->
             reverseAppend acc list1
+
+
+{-| Return the cartesian product of a list of lists.
+If one list is empty, the result is an empty list.
+If the list of lists is empty, the result is an empty singleton.
+
+    cartesianProduct [[1,2],[3,4,5],[6]] == [[1,3,6],[1,4,6],[1,5,6],[2,3,6],[2,4,6],[2,5,6]]
+    cartesianProduct [[1,2]] == [[1],[2]]
+    cartesianProduct [[1,2],[],[6]] == []
+    cartesianProduct [[]] == []
+    cartesianProduct [] == [[]]
+
+-}
+cartesianProduct : List (List a) -> List (List a)
+cartesianProduct ll =
+    case ll of
+        [] ->
+            [ [] ]
+
+        xs :: xss ->
+            lift2 (::) xs (cartesianProduct xss)
 
 
 reverseAppend : List a -> List a -> List a

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -149,6 +149,20 @@ all =
                 \() ->
                     Expect.equal (interweave [ 4, 9, 16 ] [ 2, 3, 5, 7 ]) [ 4, 2, 9, 3, 16, 5, 7 ]
             ]
+        , describe "cartesianProduct" <|
+            [ test "computes the cartesian product of lists of different length" <|
+                \() ->
+                    Expect.equal (cartesianProduct [ [ 1, 2 ], [ 3, 4, 5 ], [ 6 ] ]) [ [ 1, 3, 6 ], [ 1, 4, 6 ], [ 1, 5, 6 ], [ 2, 3, 6 ], [ 2, 4, 6 ], [ 2, 5, 6 ] ]
+            , test "computes the cartesian product of a single list" <|
+                \() ->
+                    Expect.equal (cartesianProduct [ [ 1, 2 ] ]) [ [ 1 ], [ 2 ] ]
+            , test "computes the cartesian product of lists including an empty one" <|
+                \() ->
+                    Expect.equal (cartesianProduct [ [ 1, 2 ], [], [ 6 ] ]) []
+            , test "computes the nullary cartesian product" <|
+                \() ->
+                    Expect.equal (cartesianProduct []) [ [] ]
+            ]
         , describe "foldl1" <|
             [ test "computes maximum" <|
                 \() ->


### PR DESCRIPTION
Hi,

I needed this for a project, and this is quite useful, so I thought I might as well do a pull request, in case you think it has its place in `List.Extra`.

I kept the name `sequence` because it is typically named like this for monads (like in `core/Task`) but in the list context, maybe `cartesian` or `cartesianProduct` might be better.

The implementation is almost identical to `sequence` in `core/Task` (but using `lift2` instead of `map2` to explore all combinations).