### PR TITLE
Add sliding function

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -36,6 +36,7 @@ module List.Extra
         , permutations
         , interweave
         , cartesianProduct
+        , sliding
         , foldl1
         , foldr1
         , indexedFoldl
@@ -94,7 +95,7 @@ module List.Extra
 
 # List transformations
 
-@docs intercalate, transpose, subsequences, permutations, interweave, cartesianProduct
+@docs intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, sliding
 
 
 # Folds
@@ -927,6 +928,42 @@ reverseAppend list1 list2 =
     List.foldl (::) list2 list1
 
 
+{-| Groups elements in fixed size blocks by passing a "sliding windows" over them.
+
+    sliding 1 1 [] = []
+    sliding 1 1 [1, 2, 3, 4, 5] = [[1], [2], [3], [4], [5]]
+    sliding 2 1 [1, 2, 3, 4, 5] = [[1, 2], [2, 3], [3, 4], [4, 5]]
+    sliding 1 2 [1, 2, 3, 4, 5] = [[1], [3], [5]]
+    sliding 3 1 [1, 2, 3, 4, 5] = [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+    sliding 3 3 [1, 2, 3, 4, 5] = [[1, 2, 3], [4, 5]]
+
+-}
+
+sliding : Int -> Int -> List a -> List (List a)
+sliding size step list =
+    case list of
+        [] ->
+            []
+
+        _ ->
+            slidingHelp [] (max 1 size) (max 1 step) list
+
+
+slidingHelp : List (List a) -> Int -> Int -> List a -> List (List a)
+slidingHelp acc size step list =
+    let
+        newAcc =
+            List.append acc [ List.take size list ]
+
+        remainingList =
+            List.drop step list
+    in
+        if List.length list <= size || List.length remainingList == 0 then
+            newAcc
+        else
+            slidingHelp newAcc size step remainingList
+
+
 {-| Variant of `foldl` that has no starting value argument and treats the head of the list as its starting value. If the list is empty, return `Nothing`.
 
     foldl1 max [1,2,3,2,1] == Just 3
@@ -1218,7 +1255,7 @@ The equality test should be an [equivalence relation](https://en.wikipedia.org/w
   - Symmetry - Testing two objects should give the same result regardless of the order they are passed.
   - Transitivity - If the test on a first object and a second object results in `True`, and further if the test on that second object and a third also results in `True`, then the test should result in `True` when the first and third objects are passed.
 
-For non-equivalent relations `groupWhile` has non-intuitive behavior. For example, inequality comparisons like `(<)` are not equivalence relations, so do _not_ write `groupWhile (<) [1,3,5,2,4]`, as it will give an unexpected answer.
+For non-equivalent relations `groupWhile` has non-intuitive behavior. For example, inequality comparisons like `(<)` are not equivalence relations, so do *not* write `groupWhile (<) [1,3,5,2,4]`, as it will give an unexpected answer.
 
 For grouping elements with a comparison test which is merely transitive, such as `(<)` or `(<=)`, see `groupWhileTransitively`.
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -168,6 +168,26 @@ all =
                 \() ->
                     Expect.equal (cartesianProduct []) [ [] ]
             ]
+        , describe "sliding" <|
+            [ test "return empty list on empty input" <|
+                \() ->
+                    Expect.equal (sliding 1 1 []) []
+            , test "prevent error on invalid size" <|
+                \() ->
+                    Expect.equal (sliding -1 1 [1, 2, 3]) [[1], [2], [3]]
+            , test "prevent stack overflow on invalid step" <|
+                \() ->
+                    Expect.equal (sliding 1 -1 [1, 2, 3]) [[1], [2], [3]]
+            , test "behaviour of size" <|
+                \() ->
+                    Expect.equal (sliding 3 1 [1, 2, 3, 4, 5]) [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+            , test "behaviour of step" <|
+                \() ->
+                    Expect.equal (sliding 2 3 [1, 2, 3, 4, 5]) [[1, 2], [4, 5]]
+            , test "stop when all values are used" <|
+                \() ->
+                    Expect.equal (sliding 3 3 [1, 2, 3, 4, 5]) [[1, 2, 3], [4, 5]]
+            ]
         , describe "foldl1" <|
             [ test "computes maximum" <|
                 \() ->


### PR DESCRIPTION
Hello,

I added the `sliding` function like [the one in scala list](http://www.scala-lang.org/api/2.12.3/scala/collection/immutable/List.html#sliding(size:Int,step:Int):Iterator[Repr])

Sliding lets you group a list based on a sliding windows. You can set a size which is the group size. And a step which is how many steps you take for each group. I used this function in scala a lot and i now needed in in elm. So hereby my contribution.

```elm
    sliding 1 2 [1, 2, 3, 4, 5] = [[1], [3], [5]]
    sliding 3 1 [1, 2, 3, 4, 5] = [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
```

Please let me know your thoughts and hopefully it will get accepted.

Cheers