### PR TITLE
Add mapAccuml and mapAccumr

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1085,12 +1085,13 @@ and returning a final value of this accumulator together with the new list.
 
 Add a running total to a list of numbers:
 
-    mapAccuml (\a x -> ( a + x, ( x, a + x ))) 0 [ 2, 4, 8 ] == ( 14, [ ( 2, 2 ), ( 4, 6), (8, 14) ] )
+    mapAccuml (\a x -> ( a + x, ( x, a + x ) )) 0 [ 2, 4, 8 ]
+        == ( 14, [ ( 2, 2 ), ( 4, 6 ), ( 8, 14 ) ] )
 
 Map number by multiplying with accumulated sum:
 
-    mapAccuml (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ] == ( 19, [ 10, 28, 88 ] )
-
+    mapAccuml (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ]
+        == ( 19, [ 10, 28, 88 ] )
 
 -}
 mapAccuml : (a -> b -> ( a, c )) -> a -> List b -> ( a, List c )
@@ -1125,11 +1126,13 @@ and returning a final value of this accumulator together with the new list.
 
 Add a count of remaining elements:
 
-    mapAccumr (\a x -> ( a + 1, ( x, a ))) 0 [ 2, 4, 8 ] == ( 3, [ ( 2, 2 ), ( 4, 1), ( 8, 0 ) ] )
+    mapAccumr (\a x -> ( a + 1, ( x, a ) )) 0 [ 2, 4, 8 ]
+        == ( 3, [ ( 2, 2 ), ( 4, 1 ), ( 8, 0 ) ] )
 
 Map number by multiplying with right-to-left accumulated sum:
 
-    mapAccumr (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ] == ( 19, [ 34, 52, 40 ] )
+    mapAccumr (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ]
+        == ( 19, [ 34, 52, 40 ] )
 
 -}
 mapAccumr : (a -> b -> ( a, c )) -> a -> List b -> ( a, List c )
@@ -1295,7 +1298,7 @@ The equality test should be an [equivalence relation](https://en.wikipedia.org/w
   - Symmetry - Testing two objects should give the same result regardless of the order they are passed.
   - Transitivity - If the test on a first object and a second object results in `True`, and further if the test on that second object and a third also results in `True`, then the test should result in `True` when the first and third objects are passed.
 
-For non-equivalent relations `groupWhile` has non-intuitive behavior. For example, inequality comparisons like `(<)` are not equivalence relations, so do _not_ write `groupWhile (<) [1,3,5,2,4]`, as it will give an unexpected answer.
+For non-equivalent relations `groupWhile` has non-intuitive behavior. For example, inequality comparisons like `(<)` are not equivalence relations, so do *not* write `groupWhile (<) [1,3,5,2,4]`, as it will give an unexpected answer.
 
 For grouping elements with a comparison test which is merely transitive, such as `(<)` or `(<=)`, see `groupWhileTransitively`.
 

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -43,6 +43,8 @@ module List.Extra
         , scanl1
         , scanr
         , scanr1
+        , mapAccuml
+        , mapAccumr
         , unfoldr
         , splitAt
         , splitWhen
@@ -1067,6 +1069,52 @@ scanr1 f xs_ =
 
                 [] ->
                     []
+
+
+{-| The mapAccuml function behaves like a combination of map and foldl; it applies a
+function to each element of a list, passing an accumulating parameter from left to right,
+and returning a final value of this accumulator together with the new list.
+
+    mapAccuml (\x y -> ( x + y, x * y )) 5 [ 2, 4, 8 ] == ( 19, [ 10, 28, 88 ] )
+
+-}
+mapAccuml : (a -> b -> ( a, c )) -> a -> List b -> ( a, List c )
+mapAccuml f accu0 list =
+    let
+        ( accuFinal, generatedList ) =
+            List.foldl
+                (\x ( accu1, ys ) ->
+                    let
+                        ( accu2, y ) =
+                            f accu1 x
+                    in
+                        ( accu2, y :: ys )
+                )
+                ( accu0, [] )
+                list
+    in
+        ( accuFinal, List.reverse generatedList )
+
+
+{-| The mapAccumr function behaves like a combination of map and foldl; it applies a
+function to each element of a list, passing an accumulating parameter from right to left,
+and returning a final value of this accumulator together with the new list.
+
+    mapAccumr (\x y -> ( x + y, x * y )) 5 [ 2, 4, 8 ] == ( 19, [ 34, 52, 40 ] )
+
+-}
+mapAccumr : (a -> b -> ( a, c )) -> a -> List b -> ( a, List c )
+mapAccumr f accu0 list =
+    List.foldr
+        (\x ( accu1, ys ) ->
+            let
+                ( accu2, y ) =
+                    f accu1 x
+            in
+                ( accu2, y :: ys )
+        )
+        ( accu0, [] )
+        list
 
 
 {-| The `unfoldr` function is "dual" to `foldr`. `foldr` reduces a list to a summary value, `unfoldr` builds a list from a seed. The function takes a function and a starting element. It applies the function to the element. If the result is `Just (a, b)`, `a` is accumulated and the function is applied to `b`. If the result is `Nothing`, the list accumulated so far is returned.

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1075,7 +1075,22 @@ scanr1 f xs_ =
 function to each element of a list, passing an accumulating parameter from left to right,
 and returning a final value of this accumulator together with the new list.
 
-    mapAccuml (\x y -> ( x + y, x * y )) 5 [ 2, 4, 8 ] == ( 19, [ 10, 28, 88 ] )
+    mapAccuml f a0 [ x1, x2, x3 ] == ( a3, [ y1, y2, y3 ] )
+
+    --        x1    x2    x3
+    --        |     |     |
+    --  a0 -- f --- f --- f -> a3
+    --        |     |     |
+    --        y1    y2    y3
+
+Add a running total to a list of numbers:
+
+    mapAccuml (\a x -> ( a + x, ( x, a + x ))) 0 [ 2, 4, 8 ] == ( 14, [ ( 2, 2 ), ( 4, 6), (8, 14) ] )
+
+Map number by multiplying with accumulated sum:
+
+    mapAccuml (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ] == ( 19, [ 10, 28, 88 ] )
+
 
 -}
 mapAccuml : (a -> b -> ( a, c )) -> a -> List b -> ( a, List c )
@@ -1096,11 +1111,25 @@ mapAccuml f acc0 list =
         ( accFinal, List.reverse generatedList )
 
 
-{-| The mapAccumr function behaves like a combination of map and foldl; it applies a
+{-| The mapAccumr function behaves like a combination of map and foldr; it applies a
 function to each element of a list, passing an accumulating parameter from right to left,
 and returning a final value of this accumulator together with the new list.
 
-    mapAccumr (\x y -> ( x + y, x * y )) 5 [ 2, 4, 8 ] == ( 19, [ 34, 52, 40 ] )
+    mapAccumr f a0 [ x1, x2, x3 ] == ( a3, [ y1, y2, y3 ] )
+
+    --        x1    x2    x3
+    --        |     |     |
+    --  a3 <- f --- f --- f -- a0
+    --        |     |     |
+    --        y1    y2    y3
+
+Add a count of remaining elements:
+
+    mapAccumr (\a x -> ( a + 1, ( x, a ))) 0 [ 2, 4, 8 ] == ( 3, [ ( 2, 2 ), ( 4, 1), ( 8, 0 ) ] )
+
+Map number by multiplying with right-to-left accumulated sum:
+
+    mapAccumr (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ] == ( 19, [ 34, 52, 40 ] )
 
 -}
 mapAccumr : (a -> b -> ( a, c )) -> a -> List b -> ( a, List c )

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1079,21 +1079,21 @@ and returning a final value of this accumulator together with the new list.
 
 -}
 mapAccuml : (a -> b -> ( a, c )) -> a -> List b -> ( a, List c )
-mapAccuml f accu0 list =
+mapAccuml f acc0 list =
     let
-        ( accuFinal, generatedList ) =
+        ( accFinal, generatedList ) =
             List.foldl
-                (\x ( accu1, ys ) ->
+                (\x ( acc1, ys ) ->
                     let
-                        ( accu2, y ) =
-                            f accu1 x
+                        ( acc2, y ) =
+                            f acc1 x
                     in
-                        ( accu2, y :: ys )
+                        ( acc2, y :: ys )
                 )
-                ( accu0, [] )
+                ( acc0, [] )
                 list
     in
-        ( accuFinal, List.reverse generatedList )
+        ( accFinal, List.reverse generatedList )
 
 
 {-| The mapAccumr function behaves like a combination of map and foldl; it applies a
@@ -1104,16 +1104,16 @@ and returning a final value of this accumulator together with the new list.
 
 -}
 mapAccumr : (a -> b -> ( a, c )) -> a -> List b -> ( a, List c )
-mapAccumr f accu0 list =
+mapAccumr f acc0 list =
     List.foldr
-        (\x ( accu1, ys ) ->
+        (\x ( acc1, ys ) ->
             let
-                ( accu2, y ) =
-                    f accu1 x
+                ( acc2, y ) =
+                    f acc1 x
             in
-                ( accu2, y :: ys )
+                ( acc2, y :: ys )
         )
-        ( accu0, [] )
+        ( acc0, [] )
         list
 
 

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -106,7 +106,7 @@ module List.Extra
 
 # Building lists
 
-@docs scanl1, scanr, scanr1, unfoldr, iterate, initialize, cycle
+@docs scanl1, scanr, scanr1, mapAccuml, mapAccumr, unfoldr, iterate, initialize, cycle
 
 
 # Sublists

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -220,6 +220,45 @@ all =
                 \() ->
                     Expect.equal (scanr1 (flip (-)) [ 1, 2, 3 ]) [ 0, 1, 3 ]
             ]
+        , describe "mapAccuml" <|
+            [ test "on empty list" <|
+                \() ->
+                    Expect.equal
+                        (mapAccuml (\x y -> ( x + y, x * y )) 5 [])
+                        ( 5, [] )
+            , test "accumulate sum and map product" <|
+                \() ->
+                    Expect.equal
+                        (mapAccuml (\x y -> ( x + y, x * y )) 5 [ 2, 4, 8 ])
+                        ( 19, [ 10, 28, 88 ] )
+            , test "works for very long list (i.e. is call stack size safe)" <|
+                \() ->
+                    Expect.equal
+                        (mapAccuml (\x y -> ( x + y, () )) 0 (List.range 1 100000) |> Tuple.first)
+                        5000050000
+            , test "add running total" <|
+                \() ->
+                    Expect.equal
+                        (mapAccuml (\x y -> ( x + y, ( y, x ) )) 1 [ 3, 2, 3 ])
+                        ( 9, [ ( 3, 1 ), ( 2, 4 ), ( 3, 6 ) ] )
+            ]
+        , describe "mapAccumr" <|
+            [ test "on empty list" <|
+                \() ->
+                    Expect.equal
+                        (mapAccumr (\x y -> ( x + y, x * y )) 5 [])
+                        ( 5, [] )
+            , test "accumulate sum and map product" <|
+                \() ->
+                    Expect.equal
+                        (mapAccumr (\x y -> ( x + y, x * y )) 5 [ 2, 4, 8 ])
+                        ( 19, [ 34, 52, 40 ] )
+            , test "works for very long list (i.e. is call stack size safe)" <|
+                \() ->
+                    Expect.equal
+                        (mapAccumr (\x y -> ( x + y, () )) 0 (List.range 1 100000) |> Tuple.first)
+                        5000050000
+            ]
         , describe "unfoldr" <|
             [ test "builds a decreasing list from a seed" <|
                 \() ->

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -234,7 +234,7 @@ all =
             , test "running total" <|
                 \() ->
                     Expect.equal
-                        (mapAccuml (\a x -> ( a + x, ( x, a + x ))) 0 [ 2, 4, 8 ])
+                        (mapAccuml (\a x -> ( a + x, ( x, a + x ) )) 0 [ 2, 4, 8 ])
                         ( 14, [ ( 2, 2 ), ( 4, 6 ), ( 8, 14 ) ] )
             , test "works for very long list (i.e. is call stack size safe)" <|
                 \() ->
@@ -256,8 +256,8 @@ all =
             , test "add count down" <|
                 \() ->
                     Expect.equal
-                        (mapAccumr (\a x -> ( a + 1, ( x, a ))) 0 [ 2, 4, 8 ])
-                        ( 3, [ ( 2, 2 ), ( 4, 1), ( 8, 0 ) ] )
+                        (mapAccumr (\a x -> ( a + 1, ( x, a ) )) 0 [ 2, 4, 8 ])
+                        ( 3, [ ( 2, 2 ), ( 4, 1 ), ( 8, 0 ) ] )
             , test "works for very long list (i.e. is call stack size safe)" <|
                 \() ->
                     Expect.equal

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -224,39 +224,44 @@ all =
             [ test "on empty list" <|
                 \() ->
                     Expect.equal
-                        (mapAccuml (\x y -> ( x + y, x * y )) 5 [])
+                        (mapAccuml (\a x -> ( a + x, a * x )) 5 [])
                         ( 5, [] )
             , test "accumulate sum and map product" <|
                 \() ->
                     Expect.equal
-                        (mapAccuml (\x y -> ( x + y, x * y )) 5 [ 2, 4, 8 ])
+                        (mapAccuml (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ])
                         ( 19, [ 10, 28, 88 ] )
+            , test "running total" <|
+                \() ->
+                    Expect.equal
+                        (mapAccuml (\a x -> ( a + x, ( x, a + x ))) 0 [ 2, 4, 8 ])
+                        ( 14, [ ( 2, 2 ), ( 4, 6 ), ( 8, 14 ) ] )
             , test "works for very long list (i.e. is call stack size safe)" <|
                 \() ->
                     Expect.equal
-                        (mapAccuml (\x y -> ( x + y, () )) 0 (List.range 1 100000) |> Tuple.first)
+                        (mapAccuml (\a x -> ( a + x, () )) 0 (List.range 1 100000) |> Tuple.first)
                         5000050000
-            , test "add running total" <|
-                \() ->
-                    Expect.equal
-                        (mapAccuml (\x y -> ( x + y, ( y, x ) )) 1 [ 3, 2, 3 ])
-                        ( 9, [ ( 3, 1 ), ( 2, 4 ), ( 3, 6 ) ] )
             ]
         , describe "mapAccumr" <|
             [ test "on empty list" <|
                 \() ->
                     Expect.equal
-                        (mapAccumr (\x y -> ( x + y, x * y )) 5 [])
+                        (mapAccumr (\a x -> ( a + x, a * x )) 5 [])
                         ( 5, [] )
             , test "accumulate sum and map product" <|
                 \() ->
                     Expect.equal
-                        (mapAccumr (\x y -> ( x + y, x * y )) 5 [ 2, 4, 8 ])
+                        (mapAccumr (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ])
                         ( 19, [ 34, 52, 40 ] )
+            , test "add count down" <|
+                \() ->
+                    Expect.equal
+                        (mapAccumr (\a x -> ( a + 1, ( x, a ))) 0 [ 2, 4, 8 ])
+                        ( 3, [ ( 2, 2 ), ( 4, 1), ( 8, 0 ) ] )
             , test "works for very long list (i.e. is call stack size safe)" <|
                 \() ->
                     Expect.equal
-                        (mapAccumr (\x y -> ( x + y, () )) 0 (List.range 1 100000) |> Tuple.first)
+                        (mapAccumr (\a x -> ( a + x, () )) 0 (List.range 1 100000) |> Tuple.first)
                         5000050000
             ]
         , describe "unfoldr" <|


### PR DESCRIPTION
Adding two functions `mapAccuml` and `mapAccumr` that behave like a combination of map and foldl: Pass an accumulator through the list and map the elements using the accumulator value at that point.

See [this blog post](http://colah.github.io/posts/2015-02-DataList-Illustrated/) for nice diagrams comparing `mapAccuml` with `map`, `foldl` and `scanl`.

I took the names from the [Haskell library](http://hackage.haskell.org/package/base-4.10.1.0/docs/Data-List.html#v:mapAccumL), but with a lowercase `l`/`r` at the end, following the Elm library folklore.

---

One use case is using a running total of some sort when mapping the elements of a list.

A specific application of that use case that I stumbled upon are _view_ functions, that use CSS grid-layout with items spanning across multiple cells. Say you have a model of three items, each with a specific column-span count:

```
items =
    [ { data: data1, span: 3 }
    , { data: data2, span: 2 }
    , { data: data3, span: 3 } 
    ]
```

The CSS grid spec demands that each item specifies the column number where it should start. If we adorn the list with that information it may look like this:

```
itemsWithStartColumn =
    [ { data: data1, span: 3, start: 1 }
    , { data: data2, span: 2, start: 4 }
    , { data: data3, span: 3, start: 6 } 
    ]
```

In other words, we need a running total for counting the columns already used. That's a perfect job for `mapAccuml`:

```
itemsWithStartColumn =
    mapAccuml
        (\position { data, span } ->
            ( position + span
            , { data = data, span = span, start = position }
            )
        )
        1
        items
    |> Tuple.second
```
