### PR TITLE
added List.foldlWhile function

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -12,6 +12,7 @@ module List.Extra
         , reverseMap
         , takeWhile
         , dropWhile
+        , foldlWhile
         , unique
         , uniqueBy
         , allDifferent
@@ -370,6 +371,38 @@ dropWhile predicate list =
             else
                 list
 
+{-| Reduce a list from the left while result is valid.
+The function can be used in two possible scenarios:
+
+* More optimazed replacement for list |> takeWhile f |> foldl g starter
+* Reduction while accomulation value satisfies certain criteria
+
+    accomulateColor colorSum pixelColor =
+        let
+            newColorSum = colorSum + pixelColor
+        in
+            if newColorSum > 255 the
+                Nothing
+            else 
+                Just newColorSum
+
+    [10, 55, 63, 78]
+        |> foldlWhile accomulateColor 0
+-}
+foldlWhile : (a -> b -> Maybe b) -> b -> List a -> b
+foldlWhile func acc list =
+  case list of
+    [] ->
+      acc
+
+    x :: xs ->
+        case func x acc of
+            Just nextValue ->
+                foldlWhile func nextValue xs
+
+            Nothing ->
+                acc
+      
 
 {-| Remove duplicate values, keeping the first instance of each element which appears more than once.
 

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -374,8 +374,12 @@ dropWhile predicate list =
 {-| Reduce a list from the left while result is valid.
 The function can be used in two possible scenarios:
 
-* More optimazed replacement for list |> takeWhile f |> foldl g starter
-* Reduction while accomulation value satisfies certain criteria
+ * Reduction while accumulation value satisfies certain criteria 
+ * More optimized replacement for 
+    list 
+        |> takeWhile someFunction1
+        |> foldl someFunction2 someInitialValue
+
 
     accomulateColor colorSum pixelColor =
         let

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -375,7 +375,7 @@ dropWhile predicate list =
 The function can be used in two possible scenarios:
 
  * Reduction while accumulation value satisfies certain criteria 
- * More optimized replacement for 
+ * More optimized solution for a situation, when a reduction is needed only until the first unacceptable value in the list.
     list 
         |> takeWhile someFunction1
         |> foldl someFunction2 someInitialValue

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -90,7 +90,7 @@ module List.Extra
 
 # Basics
 
-@docs last, init, getAt, (!!), uncons, maximumBy, minimumBy, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, replaceIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
+@docs last, init, getAt, (!!), uncons, maximumBy, minimumBy, andMap, andThen, reverseMap, takeWhile, dropWhile, foldlWhile, unique, uniqueBy, allDifferent, allDifferentBy, replaceIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
 
 
 # List transformations

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -320,6 +320,34 @@ all =
                 \() ->
                     Expect.equal (takeWhile ((>) 19999) (range 1 20000)) (range 1 19998)
             ]
+        , describe "foldlWhile" <|
+            [ test "empty list" <|
+                \() ->
+                    Expect.equal ([] |> foldlWhile (\ v sum -> Just v) 0 ) 0
+            , test "normaly fold" <|
+                \() ->
+                    Expect.equal ([1, 2, 3] |> foldlWhile (\ v sum -> Just (v + sum)) 0 ) 6
+            , test "fold while value is valid" <|
+                \() ->
+                    let
+                        sumLessThan3 a b =
+                            if a < 3 then 
+                                Just <| a + b
+                            else 
+                                Nothing
+                    in
+                        Expect.equal ([1, 2, 3] |> foldlWhile sumLessThan3 0 ) 3
+            , test "fold while result is valid" <|
+                \() ->
+                    let
+                        sumIfLessThan3 a b =
+                            if b < 3 then 
+                                Just <| a + b
+                            else 
+                                Nothing
+                    in
+                        Expect.equal ([1, 2, 3] |> foldlWhile sumIfLessThan3 0 ) 3
+            ]
         , describe "span" <|
             [ test "splits in the middle of the list" <|
                 \() ->


### PR DESCRIPTION
List.foldlWhile function seems to be useful in two practical cases:
 * Reduction while accumulation value satisfies certain criteria 
 * More optimized solution for a situation, when a reduction is needed only until the first unacceptable value in the list.
```elm
    list 
        |> takeWhile someFunction1
        |> foldl someFunction2 someInitialValue
```

Accumulation of pixels in a grey scale image is a good example of the function use case.

```elm
    accomulateColor colorSum pixelColor =
        let
            newColorSum = colorSum + pixelColor
        in
            if newColorSum > 255 the
                Nothing
            else 
                Just newColorSum

    [10, 55, 63, 78]
        |> foldlWhile accomulateColor 0
```