### PR TITLE
Optimize List.Extra#last

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -150,8 +150,16 @@ import Tuple exposing (first, second)
 
 -}
 last : List a -> Maybe a
-last =
-    foldl1 (flip always)
+last items =
+    case items of
+        [] ->
+            Nothing
+
+        [ x ] ->
+            Just x
+
+        _ :: rest ->
+            last rest
 
 
 {-| Return all elements of the list except the last one.


### PR DESCRIPTION
While the foldl1 solution was clever, it was also relatively slow. A simple,
obvious and recursive solution is a bunch faster (same time complexity, but less
overhead).

In my mind, since list-extra is such an extremely widely used package, it should
never be too clever nor slow. Since depending on this package in a library is
also a pretty risky affair, since the risk of dependency conflicts is pretty
high, it seems like a good idea to try and have functions that are
self-contained for easier extraction.

https://ellie-app.com/dVhMTzvGda1/0 for benchmarks against the current
implementation.

On my machine, that's 470% increase for empty list, 1350% increase for 100
elements and 1266% increase for 10000 elements.