### PR TITLE
Optimize List.Extra#init

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -161,13 +161,11 @@ last =
 
 -}
 init : List a -> Maybe (List a)
-init =
-    let
-        maybe : b -> (List a -> b) -> Maybe (List a) -> b
-        maybe d f =
-            Maybe.withDefault d << Maybe.map f
-    in
-        foldr (\x -> maybe [] ((::) x) >> Just) Nothing
+init items =
+    items
+        |> List.reverse
+        |> List.tail
+        |> Maybe.map List.reverse
 
 
 {-| Returns `Just` the element at the given index in the list,


### PR DESCRIPTION
This one looks a little funky, but counterintuituvely, it's a bunch faster for
nonempty lists.

`foldr` needs two passes, too. The big win here is that it's extremely easy to
comprehend: flip it, chop off the head, flip it again.

As for why it's faster: as stated, foldr needs two passes. First, it needs to go
to the end of the list, then back to the beginning while applying a function to
every element. In this implementation, we need two passes, too, but we only
apply a single, constant time function between the passes.

https://ellie-app.com/fFq6s2PcTa1/0 for benchmarks.

Long story short, 70% slower for empty lists (since we still need to call 3
functions), 50% faster for a single element, 300 to 500% improvement for lists
of 10 to 1000 elements.