### PR TITLE
Fix behavior of foldl1

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -151,7 +151,7 @@ import Tuple exposing (first, second)
 -}
 last : List a -> Maybe a
 last =
-    foldl1 (flip always)
+    foldl1 always
 
 
 {-| Return all elements of the list except the last one.
@@ -931,23 +931,17 @@ reverseAppend list1 list2 =
 
     foldl1 max [1,2,3,2,1] == Just 3
     foldl1 max [] == Nothing
-    foldl1 (-) [1,2,3] == Just -4
+    foldl1 (-) [1,2,3] == Just 2
 
 -}
 foldl1 : (a -> a -> a) -> List a -> Maybe a
-foldl1 f xs =
-    let
-        mf x m =
-            Just
-                (case m of
-                    Nothing ->
-                        x
+foldl1 func list =
+    case list of
+        [] ->
+            Nothing
 
-                    Just y ->
-                        f y x
-                )
-    in
-        List.foldl mf Nothing xs
+        x :: xs ->
+            Just (List.foldl func x xs)
 
 
 {-| Variant of `foldr` that has no starting value argument and treats the last element of the list as its starting value. If the list is empty, return `Nothing`.

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -929,9 +929,9 @@ reverseAppend list1 list2 =
 
 {-| Variant of `foldl` that has no starting value argument and treats the head of the list as its starting value. If the list is empty, return `Nothing`.
 
-    foldl1 max [1,2,3,2,1] == Just 3
-    foldl1 max [] == Nothing
-    foldl1 (-) [1,2,3] == Just 2
+    foldl1 (-) [1,2,3,4] == Just 2
+    foldl1 (++) ["a","b","c"] == Just "cba"
+    foldl1 min [] == Nothing
 
 -}
 foldl1 : (a -> a -> a) -> List a -> Maybe a
@@ -946,9 +946,9 @@ foldl1 func list =
 
 {-| Variant of `foldr` that has no starting value argument and treats the last element of the list as its starting value. If the list is empty, return `Nothing`.
 
-    foldr1 min [1,2,3,2,1] == Just 1
+    foldr1 (-) [1,2,3,4] == Just -2
+    foldr1 (++) ["a","b","c"] == Just "abc"
     foldr1 min [] == Nothing
-    foldr1 (-) [1,2,3] == Just 2
 
 -}
 foldr1 : (a -> a -> a) -> List a -> Maybe a

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -952,19 +952,8 @@ foldl1 func list =
 
 -}
 foldr1 : (a -> a -> a) -> List a -> Maybe a
-foldr1 f xs =
-    let
-        mf x m =
-            Just
-                (case m of
-                    Nothing ->
-                        x
-
-                    Just y ->
-                        f x y
-                )
-    in
-        List.foldr mf Nothing xs
+foldr1 func list =
+    foldl1 func (List.reverse list)
 
 
 {-| Variant of `foldl` that passes the index of the current element to the step function. `indexedFoldl` is to `List.foldl` as `List.indexedMap` is to `List.map`.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -189,7 +189,7 @@ all =
             , test "computes right to left difference" <|
                 \() ->
                     Expect.equal (foldr1 (-) [ 1, 2, 3, 4 ]) (Just -2)
-            , test "falls back to Nothing" <|
+            , test "concats properly" <|
                 \() ->
                     Expect.equal (foldr1 (++) [ "a", "b", "c" ]) (Just "abc")
             , test "falls back to Nothing" <|

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -169,26 +169,32 @@ all =
                     Expect.equal (cartesianProduct []) [ [] ]
             ]
         , describe "foldl1" <|
-            [ test "computes maximum" <|
+            [ test "computes minimum" <|
                 \() ->
-                    Expect.equal (foldl1 max [ 1, 2, 3, 2, 1 ]) (Just 3)
-            , test "falls back to Nothing" <|
-                \() ->
-                    Expect.equal (foldl1 max []) Nothing
+                    Expect.equal (foldl1 min [ 1, 2, 3, 2, 1 ]) (Just 1)
             , test "computes left to right difference" <|
                 \() ->
-                    Expect.equal (foldl1 (-) [ 1, 2, 3 ]) (Just 2)
+                    Expect.equal (foldl1 (-) [ 1, 2, 3, 4 ]) (Just 2)
+            , test "concats in reverse" <|
+                \() ->
+                    Expect.equal (foldl1 (++) [ "a", "b", "c" ]) (Just "cba")
+            , test "falls back to Nothing" <|
+                \() ->
+                    Expect.equal (foldl1 min []) Nothing
             ]
         , describe "foldr1" <|
             [ test "computes minimum" <|
                 \() ->
                     Expect.equal (foldr1 min [ 1, 2, 3, 2, 1 ]) (Just 1)
+            , test "computes right to left difference" <|
+                \() ->
+                    Expect.equal (foldr1 (-) [ 1, 2, 3, 4 ]) (Just -2)
+            , test "falls back to Nothing" <|
+                \() ->
+                    Expect.equal (foldr1 (++) [ "a", "b", "c" ]) (Just "abc")
             , test "falls back to Nothing" <|
                 \() ->
                     Expect.equal (foldr1 min []) Nothing
-            , test "computes right to left difference" <|
-                \() ->
-                    Expect.equal (foldr1 (-) [ 1, 2, 3 ]) (Just 2)
             ]
         , describe "scanl1" <|
             [ test "computes left to right iterative sum" <|

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -177,7 +177,7 @@ all =
                     Expect.equal (foldl1 max []) Nothing
             , test "computes left to right difference" <|
                 \() ->
-                    Expect.equal (foldl1 (-) [ 1, 2, 3 ]) (Just -4)
+                    Expect.equal (foldl1 (-) [ 1, 2, 3 ]) (Just 2)
             ]
         , describe "foldr1" <|
             [ test "computes minimum" <|


### PR DESCRIPTION
The behavior of `foldl1` is not in line with the behavior of `List.foldl`. The problem is that the accumulator for `List.foldl` is the second argument of the "combine" function while for `foldl1`, it is the first argument. The cause of this mistake can be traced most likely to Haskell, where the type of [`foldl`](https://hackage.haskell.org/package/base-4.10.1.0/docs/Prelude.html#v:foldl) is `(b -> a -> b) -> b -> List a -> b`, i.e. the combine function is implicitly flipped.

I have corrected the behavior which incidentally also lead to faster implementations for `foldl1` and `foldr1`. I also wrote better examples for both functions that more clearly demonstrate the difference between them.

*Note that the changes that I made are breaking despite the type of `foldl1` being unchanged.*