### PR TITLE
Fix performance regression in List.Extra#init

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -170,10 +170,15 @@ last items =
 -}
 init : List a -> Maybe (List a)
 init items =
-    items
-        |> List.reverse
-        |> List.tail
-        |> Maybe.map List.reverse
+    case items of
+        [] ->
+            Nothing
+
+        nonEmptyList ->
+            nonEmptyList
+                |> List.reverse
+                |> List.tail
+                |> Maybe.map List.reverse
 
 
 {-| Returns `Just` the element at the given index in the list,


### PR DESCRIPTION
Commit 5fa63ca introduced a performance improvement for non empty lists
but also a ~70% performance regression for empty lists. This commit
fixes the regression while also improving the performance ~30% for
empty lists before 5fa63ca.

https://ellie-app.com/5K7f2nGwsa1/1 for benchmarks.