### PR TITLE
Add cartesianProduct2

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -36,6 +36,7 @@ module List.Extra
         , permutations
         , interweave
         , cartesianProduct
+        , cartesianProduct2
         , foldl1
         , foldr1
         , indexedFoldl
@@ -96,7 +97,7 @@ module List.Extra
 
 # List transformations
 
-@docs intercalate, transpose, subsequences, permutations, interweave, cartesianProduct
+@docs intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, cartesianProduct2
 
 
 # Folds
@@ -933,6 +934,24 @@ cartesianProduct ll =
 
         xs :: xss ->
             lift2 (::) xs (cartesianProduct xss)
+
+
+{-| Return the cartesian product of two lists as a list of pairs (not a list of lists).
+This provides additional type safety when you know you are dealing with exactly two lists.
+If one list is empty, the result is an empty list.
+
+    cartesianProduct2 [1, 2] ["a", "b"] == [(1, "a"), (1, "b"), (2, "a"), (2, "b")]
+    cartesianProduct2 [1, 2] [] == []
+
+-}
+cartesianProduct2 : List a -> List b -> List ( a, b )
+cartesianProduct2 xs ys =
+    case xs of
+        x :: xs ->
+            List.map (\y -> ( x, y )) ys ++ cartesianProduct2 xs ys
+
+        [] ->
+            []
 
 
 reverseAppend : List a -> List a -> List a

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -168,6 +168,17 @@ all =
                 \() ->
                     Expect.equal (cartesianProduct []) [ [] ]
             ]
+        , describe "cartesianProduct2" <|
+            [ test "computes the cartesian product of lists of different length" <|
+                \() ->
+                    Expect.equal (cartesianProduct2 [1, 2, 3] ["a", "b"]) [(1,"a"),(1,"b"),(2,"a"),(2,"b"),(3,"a"),(3,"b")]
+            , test "computes the cartesian product of lists f different length" <|
+                \() ->
+                    Expect.equal (cartesianProduct2 [1, 2] ["a", "b"]) [(1, "a"), (1, "b"), (2, "a"), (2, "b")]
+            , test "computes the cartesian product of an empty list" <|
+                \() ->
+                    Expect.equal (cartesianProduct2 [ 1, 2 ] []) []
+            ]
         , describe "foldl1" <|
             [ test "computes maximum" <|
                 \() ->


### PR DESCRIPTION
This is a variation of `cartesianProduct` for when exactly two lists are being used. Instead of a list of lists -- the inner lists having length 2 -- the inner lists are replaced by pairs.

This came up in a project I was working on. Just as a sketch of utility, expanding a tree according to all possible transformations of an element:

```elm

type Tree a = Leaf a | Branch (Tree a) (Tree a)

transform : (a -> List a) -> Tree a -> List (Tree a)
transform f tree =
  case tree of
     Leaf x -> f x |> List.map Leaf
     Branch left right ->
        let
           lefts = transform f left
           rights = transform f right
        in case ( lefts, rights ) of
           ( [], [] ) -> [ tree ]

           ( _, [] ) ->
                    List.map (\bc -> Branch bc right) lefts

           ( [], _ ) ->
                    List.map (\bc -> Branch left bc) rights

           ( _, _ ) ->
                    cartesianProduct2 lefts rights
                        |> List.map (uncurry Branch)
```