### PR TITLE
Change group/groupWhile to use a tuple to represent a non-empty list

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.1.0",
+    "version": "8.0.0",
     "summary": "Convenience functions for working with List",
     "repository": "https://github.com/elm-community/list-extra.git",
     "license": "MIT",

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1277,7 +1277,7 @@ stripPrefix prefix xs =
     group [1,2,2,3,3,3,2,2,1] == [[1],[2,2],[3,3,3],[2,2],[1]]
 
 -}
-group : List a -> List (List a)
+group : List a -> List (a, List a)
 group =
     groupWhile (==)
 
@@ -1297,7 +1297,7 @@ For non-equivalent relations `groupWhile` has non-intuitive behavior. For exampl
 For grouping elements with a comparison test which is merely transitive, such as `(<)` or `(<=)`, see `groupWhileTransitively`.
 
 -}
-groupWhile : (a -> a -> Bool) -> List a -> List (List a)
+groupWhile : (a -> a -> Bool) -> List a -> List (a, List a)
 groupWhile eq xs_ =
     case xs_ of
         [] ->
@@ -1308,7 +1308,7 @@ groupWhile eq xs_ =
                 ( ys, zs ) =
                     span (eq x) xs
             in
-                (x :: ys) :: groupWhile eq zs
+                (x , ys) :: groupWhile eq zs
 
 
 {-| Group elements together, using a custom comparison test. Start a new group each time the comparison test doesn't hold for two adjacent elements.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -412,19 +412,20 @@ all =
         , describe "group" <|
             [ test "groups elements correctly" <|
                 \() ->
-                    Expect.equal (group [ 1, 2, 2, 3, 3, 3, 2, 2, 1 ]) [ [ 1 ], [ 2, 2 ], [ 3, 3, 3 ], [ 2, 2 ], [ 1 ] ]
+                    Expect.equal (group [ 1, 2, 2, 3, 3, 3, 2, 2, 1 ])
+                        [ ( 1, [] ), ( 2, [ 2 ] ), ( 3, [ 3, 3 ] ), ( 2, [ 2 ] ), ( 1, [] ) ]
             ]
         , describe "groupWhile" <|
             [ test "groups by sub-element equality" <|
                 \() ->
                     Expect.equal
                         (groupWhile (\x y -> first x == first y) [ ( 0, 'a' ), ( 0, 'b' ), ( 1, 'c' ), ( 1, 'd' ) ])
-                        [ [ ( 0, 'a' ), ( 0, 'b' ) ], [ ( 1, 'c' ), ( 1, 'd' ) ] ]
+                        [ ( ( 0, 'a' ), [ ( 0, 'b' ) ] ), ( ( 1, 'c' ), [ ( 1, 'd' ) ] ) ]
             , test "comparison function is reflexive, symmetric, and transitive" <|
                 \() ->
                     Expect.equal
                         (groupWhile (<) [ 1, 2, 3, 2, 4, 1, 3, 2, 1 ])
-                        [ [ 1, 2, 3, 2, 4 ], [ 1, 3, 2 ], [ 1 ] ]
+                        [ ( 1, [ 2, 3, 2, 4 ] ), ( 1, [ 3, 2 ] ), ( 1, [] ) ]
             ]
         , describe "groupWhileTransitively" <|
             [ test "an empty list" <|


### PR DESCRIPTION
Quote from @evancz in the slack: 

> Someone mentioned that using `List.Extra.groupWhile` is annoying because you are guaranteed to get at least one entry in every single list, but you then have to pattern match and handle the empty case anyway. Can it be changed to the following type?
> 
> ```groupWhile : (a -> a -> Bool) -> List a -> List (a, List a)```
>
> I am going to be emphasizing to people that “non-empty lists” are not hard to represent, no special library needed. I think doing it as a tuple is a fine way

This PR does just that.