### PR TITLE
Add gatherEquals function.

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -112,7 +112,7 @@ module List.Extra
 
 # Sublists
 
-@docs splitAt, splitWhen, takeWhileRight, dropWhileRight, span, break, stripPrefix, group, groupWhile, inits, tails, select, selectSplit, gatherEquals
+@docs splitAt, splitWhen, takeWhileRight, dropWhileRight, span, break, stripPrefix, group, groupWhile, inits, tails, select, selectSplit, gatherEquals, gatherEqualsBy, gatherWith
 
 
 # Predicates

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1679,9 +1679,9 @@ greedyGroupsOfWithStep size step xs =
 {-| Group equal elements together. This is different from `group` as each sublist
 will contain *all* equal elements of the original list.
 
-    gatherEquals [1,2,1,3,2] == [[1,1],[2,2],[3]]
+    gatherEquals [1,2,1,3,2] == [(1,[1]),(2,[2]),(3,[])]
 -}
-gatherEquals : List a -> List (List a)
+gatherEquals : List a -> List (a, List a)
 gatherEquals list =
     gatherEqualsWith (==) list
 
@@ -1689,21 +1689,21 @@ gatherEquals list =
 {-| Group equal elements together. A function is applied to each element of the list
 and then the equality check is performed against the results of that function evaluation.
 
-    gatherEqualsBy .name [{age=25},{age=23},{age=25}] == [[{age=25},{age=25}],[{age=23}]]
+    gatherEqualsBy .name [{age=25},{age=23},{age=25}] == [({age=25},[{age=25}]),({age=23},[])]
 -}
-gatherEqualsBy : (a -> b) -> List a -> List (List a)
+gatherEqualsBy : (a -> b) -> List a -> List (a, List a)
 gatherEqualsBy extract list =
     gatherEqualsWith (\a b -> (extract a) == (extract b)) list
 
 
 {-| Group equal elements together using a custom equality function.
 
-    gatherEquals (==) [1,2,1,3,2] == [[1,1],[2,2],[3]]
+    gatherEquals (==) [1,2,1,3,2] == [(1,[1]),(2,[2]),(3,[])]
 -}
-gatherEqualsWith : (a -> a -> Bool) -> List a -> List (List a)
+gatherEqualsWith : (a -> a -> Bool) -> List a -> List (a, List a)
 gatherEqualsWith testFn list =
     let
-        helper : List a -> List (List a) -> List (List a)
+        helper : List a -> List (a,List a) -> List (a, List a)
         helper scattered gathered =
             case scattered of
                 [] ->
@@ -1714,6 +1714,6 @@ gatherEqualsWith testFn list =
                         ( gathering, remaining ) =
                             List.partition (testFn toGather) population
                     in
-                    helper remaining <| (toGather :: gathering) :: gathered
+                    helper remaining <| (toGather, gathering) :: gathered
     in
     helper list []

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1863,7 +1863,8 @@ will contain *all* equal elements of the original list. Elements will be grouped
 in the same order as they appear in the original list. The same applies to elements
 within each group.
 
-    gatherEquals [1,2,1,3,2] == [(1,[1]),(2,[2]),(3,[])]
+    gatherEquals [1,2,1,3,2] 
+    --> [(1,[1]),(2,[2]),(3,[])]
 -}
 gatherEquals : List a -> List (a, List a)
 gatherEquals list =
@@ -1875,7 +1876,8 @@ and then the equality check is performed against the results of that function ev
 Elements will be grouped in the same order as they appear in the original list. The
 same applies to elements within each group.
 
-    gatherEqualsBy .age [{age=25},{age=23},{age=25}] == [({age=25},[{age=25}]),({age=23},[])]
+    gatherEqualsBy .age [{age=25},{age=23},{age=25}] 
+    --> [({age=25},[{age=25}]),({age=23},[])]
 -}
 gatherEqualsBy : (a -> b) -> List a -> List (a, List a)
 gatherEqualsBy extract list =
@@ -1886,7 +1888,8 @@ gatherEqualsBy extract list =
 grouped in the same order as they appear in the original list. The same applies to
 elements within each group.
 
-    gatherWith (==) [1,2,1,3,2] == [(1,[1]),(2,[2]),(3,[])]
+    gatherWith (==) [1,2,1,3,2] 
+    --> [(1,[1]),(2,[2]),(3,[])]
 -}
 gatherWith : (a -> a -> Bool) -> List a -> List (a, List a)
 gatherWith testFn list =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1677,7 +1677,9 @@ greedyGroupsOfWithStep size step xs =
         []
 
 {-| Group equal elements together. This is different from `group` as each sublist
-will contain *all* equal elements of the original list.
+will contain *all* equal elements of the original list. Elements will be grouped
+in the same order as they appear in the original list. The same applies to elements
+within each group.
 
     gatherEquals [1,2,1,3,2] == [(1,[1]),(2,[2]),(3,[])]
 -}
@@ -1688,6 +1690,8 @@ gatherEquals list =
 
 {-| Group equal elements together. A function is applied to each element of the list
 and then the equality check is performed against the results of that function evaluation.
+Elements will be grouped in the same order as they appear in the original list. The
+same applies to elements within each group.
 
     gatherEqualsBy .age [{age=25},{age=23},{age=25}] == [({age=25},[{age=25}]),({age=23},[])]
 -}
@@ -1696,7 +1700,9 @@ gatherEqualsBy extract list =
     gatherWith (\a b -> (extract a) == (extract b)) list
 
 
-{-| Group equal elements together using a custom equality function.
+{-| Group equal elements together using a custom equality function. Elements will be
+grouped in the same order as they appear in the original list. The same applies to
+elements within each group.
 
     gatherWith (==) [1,2,1,3,2] == [(1,[1]),(2,[2]),(3,[])]
 -}

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -20,7 +20,7 @@ module List.Extra
         , foldr1
         , gatherEquals
         , gatherEqualsBy
-        , gatherEqualsWith
+        , gatherWith
         , getAt
         , greedyGroupsOf
         , greedyGroupsOfWithStep
@@ -1683,7 +1683,7 @@ will contain *all* equal elements of the original list.
 -}
 gatherEquals : List a -> List (a, List a)
 gatherEquals list =
-    gatherEqualsWith (==) list
+    gatherWith (==) list
 
 
 {-| Group equal elements together. A function is applied to each element of the list
@@ -1693,15 +1693,15 @@ and then the equality check is performed against the results of that function ev
 -}
 gatherEqualsBy : (a -> b) -> List a -> List (a, List a)
 gatherEqualsBy extract list =
-    gatherEqualsWith (\a b -> (extract a) == (extract b)) list
+    gatherWith (\a b -> (extract a) == (extract b)) list
 
 
 {-| Group equal elements together using a custom equality function.
 
-    gatherEquals (==) [1,2,1,3,2] == [(1,[1]),(2,[2]),(3,[])]
+    gatherWith (==) [1,2,1,3,2] == [(1,[1]),(2,[2]),(3,[])]
 -}
-gatherEqualsWith : (a -> a -> Bool) -> List a -> List (a, List a)
-gatherEqualsWith testFn list =
+gatherWith : (a -> a -> Bool) -> List a -> List (a, List a)
+gatherWith testFn list =
     let
         helper : List a -> List (a,List a) -> List (a, List a)
         helper scattered gathered =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1689,7 +1689,7 @@ gatherEquals list =
 {-| Group equal elements together. A function is applied to each element of the list
 and then the equality check is performed against the results of that function evaluation.
 
-    gatherEqualsBy .name [{age=25},{age=23},{age=25}] == [({age=25},[{age=25}]),({age=23},[])]
+    gatherEqualsBy .age [{age=25},{age=23},{age=25}] == [({age=25},[{age=25}]),({age=23},[])]
 -}
 gatherEqualsBy : (a -> b) -> List a -> List (a, List a)
 gatherEqualsBy extract list =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -18,6 +18,7 @@ module List.Extra
         , findIndices
         , foldl1
         , foldr1
+        , gatherEquals
         , getAt
         , greedyGroupsOf
         , greedyGroupsOfWithStep
@@ -109,7 +110,7 @@ module List.Extra
 
 # Sublists
 
-@docs splitAt, splitWhen, takeWhileRight, dropWhileRight, span, break, stripPrefix, group, groupWhile, inits, tails, select, selectSplit
+@docs splitAt, splitWhen, takeWhileRight, dropWhileRight, span, break, stripPrefix, group, groupWhile, inits, tails, select, selectSplit, gatherEquals
 
 
 # Predicates
@@ -1672,3 +1673,26 @@ greedyGroupsOfWithStep size step xs =
         List.take size xs :: greedyGroupsOfWithStep size step xs_
     else
         []
+
+{-| Group equal elements together. This is different from `group` as each sublist
+will contain *all* equal elements of the original list.
+
+    gatherEquals [1,2,1,3,2] == [[1,1],[2,2],[3]]
+-}
+gatherEquals : List a -> List (List a)
+gatherEquals list =
+    let
+        helper : List a -> List (List a) -> List (List a)
+        helper scattered gathered =
+            case scattered of
+                [] ->
+                    List.reverse gathered
+
+                toGather :: population ->
+                    let
+                        ( gathering, remaining ) =
+                            List.partition (\e -> e == toGather) population
+                    in
+                    helper remaining <| (toGather :: gathering) :: gathered
+    in
+    helper list []

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -19,6 +19,8 @@ module List.Extra
         , foldl1
         , foldr1
         , gatherEquals
+        , gatherEqualsBy
+        , gatherEqualsWith
         , getAt
         , greedyGroupsOf
         , greedyGroupsOfWithStep
@@ -1681,6 +1683,25 @@ will contain *all* equal elements of the original list.
 -}
 gatherEquals : List a -> List (List a)
 gatherEquals list =
+    gatherEqualsWith (==) list
+
+
+{-| Group equal elements together. A function is applied to each element of the list
+and then the equality check is performed against the results of that function evaluation.
+
+    gatherEqualsBy .name [{age=25},{age=23},{age=25}] == [[{age=25},{age=25}],[{age=23}]]
+-}
+gatherEqualsBy : (a -> b) -> List a -> List (List a)
+gatherEqualsBy extract list =
+    gatherEqualsWith (\a b -> (extract a) == (extract b)) list
+
+
+{-| Group equal elements together using a custom equality function.
+
+    gatherEquals (==) [1,2,1,3,2] == [[1,1],[2,2],[3]]
+-}
+gatherEqualsWith : (a -> a -> Bool) -> List a -> List (List a)
+gatherEqualsWith testFn list =
     let
         helper : List a -> List (List a) -> List (List a)
         helper scattered gathered =
@@ -1691,7 +1712,7 @@ gatherEquals list =
                 toGather :: population ->
                     let
                         ( gathering, remaining ) =
-                            List.partition (\e -> e == toGather) population
+                            List.partition (testFn toGather) population
                     in
                     helper remaining <| (toGather :: gathering) :: gathered
     in

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -704,4 +704,42 @@ all =
                             , [ 4 ]
                             ]
             ]
+        , describe "gatherEqualsBy"
+            [ test "empty list" <|
+                \() ->
+                    gatherEqualsBy identity []
+                        |> Expect.equal []
+            , test "single element" <|
+                \() ->
+                    gatherEqualsBy identity [ 1 ]
+                        |> Expect.equal [ [ 1 ] ]
+            , test "proper test" <|
+                \() ->
+                    gatherEqualsBy identity [ 1, 2, 1, 2, 3, 4, 1 ]
+                        |> Expect.equal
+                            [ [ 1, 1, 1 ]
+                            , [ 2, 2 ]
+                            , [ 3 ]
+                            , [ 4 ]
+                            ]
+            ]
+        , describe "gatherEqualsWith"
+            [ test "empty list" <|
+                \() ->
+                    gatherEqualsWith (==) []
+                        |> Expect.equal []
+            , test "single element" <|
+                \() ->
+                    gatherEqualsWith (==) [ 1 ]
+                        |> Expect.equal [ [ 1 ] ]
+            , test "proper test" <|
+                \() ->
+                    gatherEqualsWith (==) [ 1, 2, 1, 2, 3, 4, 1 ]
+                        |> Expect.equal
+                            [ [ 1, 1, 1 ]
+                            , [ 2, 2 ]
+                            , [ 3 ]
+                            , [ 4 ]
+                            ]
+            ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -723,18 +723,18 @@ all =
                             , ( 4, [])
                             ]
             ]
-        , describe "gatherEqualsWith"
+        , describe "gatherWith"
             [ test "empty list" <|
                 \() ->
-                    gatherEqualsWith (==) []
+                    gatherWith (==) []
                         |> Expect.equal []
             , test "single element" <|
                 \() ->
-                    gatherEqualsWith (==) [ 1 ]
+                    gatherWith (==) [ 1 ]
                         |> Expect.equal [ (1, []) ]
             , test "proper test" <|
                 \() ->
-                    gatherEqualsWith (==) [ 1, 2, 1, 2, 3, 4, 1 ]
+                    gatherWith (==) [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
                             [ ( 1, [ 1, 1 ])
                             , ( 2, [ 2 ])

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -685,4 +685,23 @@ all =
                 \() ->
                     Expect.equal (setIf (\x -> modBy 2 x == 0) 0 [ 17, 8, 2, 9 ]) [ 17, 0, 0, 9 ]
             ]
+        , describe "gatherEquals"
+            [ test "empty list" <|
+                \() ->
+                    gatherEquals []
+                        |> Expect.equal []
+            , test "single element" <|
+                \() ->
+                    gatherEquals [ 1 ]
+                        |> Expect.equal [ [ 1 ] ]
+            , test "proper test" <|
+                \() ->
+                    gatherEquals [ 1, 2, 1, 2, 3, 4, 1 ]
+                        |> Expect.equal
+                            [ [ 1, 1, 1 ]
+                            , [ 2, 2 ]
+                            , [ 3 ]
+                            , [ 4 ]
+                            ]
+            ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -693,15 +693,15 @@ all =
             , test "single element" <|
                 \() ->
                     gatherEquals [ 1 ]
-                        |> Expect.equal [ [ 1 ] ]
+                        |> Expect.equal [ (1, []) ]
             , test "proper test" <|
                 \() ->
                     gatherEquals [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
-                            [ [ 1, 1, 1 ]
-                            , [ 2, 2 ]
-                            , [ 3 ]
-                            , [ 4 ]
+                            [ ( 1, [ 1, 1 ])
+                            , ( 2, [ 2 ])
+                            , ( 3, [])
+                            , ( 4, [])
                             ]
             ]
         , describe "gatherEqualsBy"
@@ -712,15 +712,15 @@ all =
             , test "single element" <|
                 \() ->
                     gatherEqualsBy identity [ 1 ]
-                        |> Expect.equal [ [ 1 ] ]
+                        |> Expect.equal [ (1, []) ]
             , test "proper test" <|
                 \() ->
                     gatherEqualsBy identity [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
-                            [ [ 1, 1, 1 ]
-                            , [ 2, 2 ]
-                            , [ 3 ]
-                            , [ 4 ]
+                            [ ( 1, [ 1, 1 ])
+                            , ( 2, [ 2 ])
+                            , ( 3, [])
+                            , ( 4, [])
                             ]
             ]
         , describe "gatherEqualsWith"
@@ -731,15 +731,15 @@ all =
             , test "single element" <|
                 \() ->
                     gatherEqualsWith (==) [ 1 ]
-                        |> Expect.equal [ [ 1 ] ]
+                        |> Expect.equal [ (1, []) ]
             , test "proper test" <|
                 \() ->
                     gatherEqualsWith (==) [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
-                            [ [ 1, 1, 1 ]
-                            , [ 2, 2 ]
-                            , [ 3 ]
-                            , [ 4 ]
+                            [ ( 1, [ 1, 1 ])
+                            , ( 2, [ 2 ])
+                            , ( 3, [])
+                            , ( 4, [])
                             ]
             ]
         ]


### PR DESCRIPTION
This is similar to `group`, except it groups all equal elements in a single sub-list. I'm open to change the name to something better.