### PR TITLE
Tests for maximum by and minimum by

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pull requests are welcome. You can expect some kind of response within 5 days.
 If you are proposing a new function be added, please adhere to the following..
 
 1. Include [documentation](http://package.elm-lang.org/help/documentation-format) and make sure your documentation has a code snippet demonstrating what the function does. We use [elm-verify-examples](https://github.com/stoeffel/elm-verify-examples) in our travis set up which verifies our examples that our example code is correct, so please take advantage of that.
-2. Provide a detailed use case where your new function would be useful. Also, compare your new function to the best possible implementation that doesnt include use your function.
+2. Provide a detailed use case where your new function would be useful. Also, compare your new function to the best possible implementation that doesn't include use your function.
 3. Add tests to `Tests/Tests.elm`
 
 If you are improving existing functions please demonstrate the performance gains in something like [Ellie](https://ellie-app.com/) and by using a benchmark library like [this one](http://package.elm-lang.org/packages/BrianHicks/elm-benchmark/latest).

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -684,6 +684,14 @@ all =
                         (maximumWith (\x y -> compare x.val y.val) [ { id = 1, val = 1 }, { id = 2, val = 2 }, { id = 3, val = 2 } ])
                         (Just { id = 2, val = 2 })
             ]
+        , describe "maximumBy"
+            [ test "maximumBy of empty list" <|
+                \() -> Expect.equal (maximumBy (\x -> x) []) Nothing
+            , test "first maximumBy of records list" <|
+                \() ->
+                    Expect.equal (maximumBy (\x -> x.val) [ { id = 1, val = 1 }, { id = 2, val = 2 }, { id = 3, val = 2 } ])
+                        (Just { id = 2, val = 2 })
+            ]
         , describe "minimumWith"
             [ test "minimum of empty list" <|
                 \() ->
@@ -692,6 +700,14 @@ all =
                 \() ->
                     Expect.equal
                         (minimumWith (\x y -> compare x.val y.val) [ { id = 1, val = 2 }, { id = 2, val = 1 }, { id = 3, val = 1 } ])
+                        (Just { id = 2, val = 1 })
+            ]
+        , describe "minimumBy"
+            [ test "minimumBy of empty list" <|
+                \() -> Expect.equal (minimumBy (\x -> x) []) Nothing
+            , test "first minimumBy of records list" <|
+                \() ->
+                    Expect.equal (minimumBy (\x -> x.val) [ { id = 1, val = 2 }, { id = 2, val = 1 }, { id = 3, val = 1 } ])
                         (Just { id = 2, val = 1 })
             ]
         , describe "setIf"
@@ -713,15 +729,15 @@ all =
             , test "single element" <|
                 \() ->
                     gatherEquals [ 1 ]
-                        |> Expect.equal [ (1, []) ]
+                        |> Expect.equal [ ( 1, [] ) ]
             , test "proper test" <|
                 \() ->
                     gatherEquals [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
-                            [ ( 1, [ 1, 1 ])
-                            , ( 2, [ 2 ])
-                            , ( 3, [])
-                            , ( 4, [])
+                            [ ( 1, [ 1, 1 ] )
+                            , ( 2, [ 2 ] )
+                            , ( 3, [] )
+                            , ( 4, [] )
                             ]
             ]
         , describe "gatherEqualsBy"
@@ -732,15 +748,15 @@ all =
             , test "single element" <|
                 \() ->
                     gatherEqualsBy identity [ 1 ]
-                        |> Expect.equal [ (1, []) ]
+                        |> Expect.equal [ ( 1, [] ) ]
             , test "proper test" <|
                 \() ->
                     gatherEqualsBy identity [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
-                            [ ( 1, [ 1, 1 ])
-                            , ( 2, [ 2 ])
-                            , ( 3, [])
-                            , ( 4, [])
+                            [ ( 1, [ 1, 1 ] )
+                            , ( 2, [ 2 ] )
+                            , ( 3, [] )
+                            , ( 4, [] )
                             ]
             ]
         , describe "gatherWith"
@@ -751,15 +767,15 @@ all =
             , test "single element" <|
                 \() ->
                     gatherWith (==) [ 1 ]
-                        |> Expect.equal [ (1, []) ]
+                        |> Expect.equal [ ( 1, [] ) ]
             , test "proper test" <|
                 \() ->
                     gatherWith (==) [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
-                            [ ( 1, [ 1, 1 ])
-                            , ( 2, [ 2 ])
-                            , ( 3, [])
-                            , ( 4, [])
+                            [ ( 1, [ 1, 1 ] )
+                            , ( 2, [ 2 ] )
+                            , ( 3, [] )
+                            , ( 4, [] )
                             ]
             ]
         ]


### PR DESCRIPTION
I noticed that there were no tests for maximumBy and minimumBy, so I added some simple tests for both of them (in essence, I copied the tests for maximumWith / minimumWith and changed the predicate)