### PR TITLE
Add `pairings` function

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1071,13 +1071,7 @@ cartesianProduct ll =
 (Essentially, enumerate the possible "handshakes.")
 
     pairings [ 1, 2, 3, 4 ]
-    --> [ ( 1, 2 )
-        , ( 1, 3 )
-        , ( 1, 4 )
-        , ( 2, 3 )
-        , ( 2, 4 )
-        , ( 3, 4 )
-        ]
+    --> [ ( 1, 2 ), ( 1, 3 ), ( 1, 4 ), ( 2, 3 ), ( 2, 4 ), ( 3, 4 ) ]
 
 In this example, everybody shakes hands with three other people.
 

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1,7 +1,7 @@
 
 module List.Extra exposing
     ( last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
-    , intercalate, transpose, subsequences, permutations, interweave, cartesianProduct
+    , intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, pairings
     , foldl1, foldr1, indexedFoldl, indexedFoldr
     , scanl, scanl1, scanr, scanr1, mapAccuml, mapAccumr, unfoldr, iterate, initialize, cycle
     , splitAt, splitWhen, takeWhileRight, dropWhileRight, span, break, stripPrefix, group, groupWhile, inits, tails, select, selectSplit, gatherEquals, gatherEqualsBy, gatherWith
@@ -23,7 +23,7 @@ module List.Extra exposing
 
 # List transformations
 
-@docs intercalate, transpose, subsequences, permutations, interweave, cartesianProduct
+@docs intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, pairings
 
 
 # Folds
@@ -1065,6 +1065,31 @@ cartesianProduct ll =
 
         xs :: xss ->
             lift2 (::) xs (cartesianProduct xss)
+
+
+{-| Return all ways to pair the elements of the list.
+(Essentially, enumerate the possible "handshakes.")
+
+    pairings [ 1, 2, 3, 4 ]
+    --> [ ( 1, 2 )
+        , ( 1, 3 )
+        , ( 1, 4 )
+        , ( 2, 3 )
+        , ( 2, 4 )
+        , ( 3, 4 )
+        ]
+
+In this example, everybody shakes hands with three other people.
+
+-}
+pairings : List a -> List ( a, a )
+pairings xs =
+    case xs of
+        [] ->
+            []
+
+        x :: xs_ ->
+            List.map (\y -> ( x, y )) xs_ ++ pairings xs_
 
 
 reverseAppend : List a -> List a -> List a

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1070,6 +1070,8 @@ cartesianProduct ll =
 {-| Return all ways to pair the elements of the list.
 (Essentially, enumerate the possible "handshakes.")
 
+In more mathematical terms these are 2-combinations without repetition.
+
     pairings [ 1, 2, 3, 4 ]
     --> [ ( 1, 2 ), ( 1, 3 ), ( 1, 4 ), ( 2, 3 ), ( 2, 4 ), ( 3, 4 ) ]
 

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1,7 +1,7 @@
 
 module List.Extra exposing
     ( last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
-    , intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, pairings
+    , intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, uniquePairs
     , foldl1, foldr1, indexedFoldl, indexedFoldr
     , scanl, scanl1, scanr, scanr1, mapAccuml, mapAccumr, unfoldr, iterate, initialize, cycle
     , splitAt, splitWhen, takeWhileRight, dropWhileRight, span, break, stripPrefix, group, groupWhile, inits, tails, select, selectSplit, gatherEquals, gatherEqualsBy, gatherWith
@@ -23,7 +23,7 @@ module List.Extra exposing
 
 # List transformations
 
-@docs intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, pairings
+@docs intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, uniquePairs
 
 
 # Folds
@@ -1070,22 +1070,25 @@ cartesianProduct ll =
 {-| Return all ways to pair the elements of the list.
 (Essentially, enumerate the possible "handshakes.")
 
+The order of the pair elements doesn't matter, so if `(1,2)` is a returned pair,
+we don't return `(2,1)`.
+
 In more mathematical terms these are 2-combinations without repetition.
 
-    pairings [ 1, 2, 3, 4 ]
+    uniquePairs [ 1, 2, 3, 4 ]
     --> [ ( 1, 2 ), ( 1, 3 ), ( 1, 4 ), ( 2, 3 ), ( 2, 4 ), ( 3, 4 ) ]
 
 In this example, everybody shakes hands with three other people.
 
 -}
-pairings : List a -> List ( a, a )
-pairings xs =
+uniquePairs : List a -> List ( a, a )
+uniquePairs xs =
     case xs of
         [] ->
             []
 
         x :: xs_ ->
-            List.map (\y -> ( x, y )) xs_ ++ pairings xs_
+            List.map (\y -> ( x, y )) xs_ ++ uniquePairs xs_
 
 
 reverseAppend : List a -> List a -> List a

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -778,22 +778,22 @@ all =
                             , ( 4, [] )
                             ]
             ]
-        , describe "pairings"
+        , describe "uniquePairs"
             [ test "empty list" <|
                 \() ->
-                    pairings []
+                    uniquePairs []
                         |> Expect.equal []
             , test "single element has no counterpart to pair with" <|
                 \() ->
-                    pairings [ 1 ]
+                    uniquePairs [ 1 ]
                         |> Expect.equal []
             , test "two elements have exactly one way to pair" <|
                 \() ->
-                    pairings [ 1, 2 ]
+                    uniquePairs [ 1, 2 ]
                         |> Expect.equal [ ( 1, 2 ) ]
             , test "three elements have three ways to pair" <|
                 \() ->
-                    pairings [ 1, 2, 3 ]
+                    uniquePairs [ 1, 2, 3 ]
                         |> Expect.equal [ ( 1, 2 ), ( 1, 3 ), ( 2, 3 ) ]
             ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -778,4 +778,22 @@ all =
                             , ( 4, [] )
                             ]
             ]
+        , describe "pairings"
+            [ test "empty list" <|
+                \() ->
+                    pairings []
+                        |> Expect.equal []
+            , test "single element has no counterpart to pair with" <|
+                \() ->
+                    pairings [ 1 ]
+                        |> Expect.equal []
+            , test "two elements have exactly one way to pair" <|
+                \() ->
+                    pairings [ 1, 2 ]
+                        |> Expect.equal [ ( 1, 2 ) ]
+            , test "three elements have three ways to pair" <|
+                \() ->
+                    pairings [ 1, 2, 3 ]
+                        |> Expect.equal [ ( 1, 2 ), ( 1, 3 ), ( 2, 3 ) ]
+            ]
         ]


### PR DESCRIPTION
```elm
pairings [1,2,3,4]
--> [ (1,2), (1,3), (1,4), (2,3), (2,4), (3,4) ]
```

This is essentially doing the equivalent of the following Python loop:
```python
def pairings(xs):
    return [(xs[i], xs[j]) for i in range(len(xs))
                           for j in range(i+1, len(xs))]
```
It's useful eg. for Advent of Code puzzles, or any occasion where you need to check elements of a list against each other, without duplicates and without checking against self (`(x,x)`).