### PR TITLE
Update to Elm v0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     },
     "homepage": "https://github.com/elm-community/list-extra#readme",
     "dependencies": {
-        "elm": "^0.19.0",
-        "elm-test": "^0.19.0-beta9",
-        "elm-verify-examples": "^3.0.1"
+        "elm": "^0.19.1-3",
+        "elm-test": "^0.19.1",
+        "elm-verify-examples": "^5.0.0"
     }
 }


### PR DESCRIPTION
This should fix the Travis builds, which are failing because of Node
v12.