### PR TITLE
Fix #132

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1688,7 +1688,7 @@ isInfixOfHelp infixHead infixTail list =
 
         x :: xs ->
             if x == infixHead then
-                isPrefixOf infixTail xs
+                isPrefixOf infixTail xs || isInfixOfHelp infixHead infixTail xs
 
             else
                 isInfixOfHelp infixHead infixTail xs

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1647,7 +1647,11 @@ isPrefixOf prefix list =
             False
 
         ( p :: ps, x :: xs ) ->
-            p == x && isPrefixOf ps xs
+            if p == x then
+                isPrefixOf ps xs
+
+            else
+                False
 
 
 {-| Take two lists and return `True`, if the first list is the suffix of the second list.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -581,6 +581,9 @@ all =
             , test "not in-order" <|
                 \() ->
                     Expect.false "3, 5, 2 is not infix of 2, 3, 5, 7, 11, 13" (isInfixOf [ 3, 5, 2 ] [ 2, 3, 5, 7, 11, 13 ])
+            , test "partial match then real match" <|
+                \() ->
+                    Expect.true "1, 2 is infix of 1, 3, 1, 2" (isInfixOf [ 1, 2 ] [ 1, 3, 1, 2 ])
             ]
         , describe "swapAt"
             [ test "negative index as first argument returns the original list" <|

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -547,6 +547,9 @@ all =
                         || not (List.Extra.isPrefixOf listB listC)
                         || List.Extra.isPrefixOf listA listC
                         |> Expect.true "Expected prefix of prefix to be prefix."
+            , test "stack safety" <|
+                \() ->
+                    Expect.true "1, 2, ..., 6k is prefix of 1, 2, ..., 10k" (isPrefixOf (List.range 1 6000) (List.range 1 10000))
             ]
         , describe "isSuffixOf"
             [ fuzz (list int) "[] is suffix to anything" <|
@@ -570,6 +573,9 @@ all =
                         || not (List.Extra.isSuffixOf listB listC)
                         || List.Extra.isSuffixOf listA listC
                         |> Expect.true "Expected suffix of suffix to be suffix."
+            , test "stack safety" <|
+                \() ->
+                    Expect.true "4000, 4001, ..., 10k is suffix of 1, 2, ..., 10k" (isSuffixOf (List.range 4000 10000) (List.range 1 10000))
             ]
         , describe "isInfixOf"
             [ test "success" <|
@@ -584,6 +590,9 @@ all =
             , test "partial match then real match" <|
                 \() ->
                     Expect.true "1, 2 is infix of 1, 3, 1, 2" (isInfixOf [ 1, 2 ] [ 1, 3, 1, 2 ])
+            , test "stack safety" <|
+                \() ->
+                    Expect.true "1, 2, ..., 6k is infix of 1, 2, ..., 10k" (isInfixOf (List.range 1 6000) (List.range 1 10000))
             ]
         , describe "swapAt"
             [ test "negative index as first argument returns the original list" <|

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -550,6 +550,9 @@ all =
             , test "stack safety" <|
                 \() ->
                     Expect.true "1, 2, ..., 6k is prefix of 1, 2, ..., 10k" (isPrefixOf (List.range 1 6000) (List.range 1 10000))
+            , fuzz2 (list int) (list int) "generalized fuzz test" <|
+                \prefix rest ->
+                    Expect.true "xs is prefix of xs ++ ys" (isPrefixOf prefix (prefix ++ rest))
             ]
         , describe "isSuffixOf"
             [ fuzz (list int) "[] is suffix to anything" <|
@@ -576,6 +579,9 @@ all =
             , test "stack safety" <|
                 \() ->
                     Expect.true "4000, 4001, ..., 10k is suffix of 1, 2, ..., 10k" (isSuffixOf (List.range 4000 10000) (List.range 1 10000))
+            , fuzz2 (list int) (list int) "generalized fuzz test" <|
+                \suffix rest ->
+                    Expect.true "ys is suffix of xs ++ ys" (isSuffixOf suffix (rest ++ suffix))
             ]
         , describe "isInfixOf"
             [ test "success" <|
@@ -593,6 +599,21 @@ all =
             , test "stack safety" <|
                 \() ->
                     Expect.true "1, 2, ..., 6k is infix of 1, 2, ..., 10k" (isInfixOf (List.range 1 6000) (List.range 1 10000))
+            , fuzz3 (list int) (list int) (list int) "generalized fuzz test" <|
+                \prefix match suffix ->
+                    Expect.true "ys is infix of xs ++ ys ++ zs" (isInfixOf match (prefix ++ match ++ suffix))
+            , test "empty is infix of empty" <|
+                \() ->
+                    Expect.true "empty is infix of empty" (isInfixOf [] [])
+            , fuzz (list int) "empty is infix of anything" <|
+                \list ->
+                    Expect.true "empty is infix of anything" (isInfixOf [] list)
+            , fuzz2 int (list int) "non-empty is not infix of empty" <|
+                \x xs ->
+                    Expect.false "non-empty is not infix of empty" (isInfixOf (x :: xs) [])
+            , fuzz (list int) "equal lists are infix" <|
+                \list ->
+                    Expect.true "equal lists are infix" (isInfixOf list list)
             ]
         , describe "swapAt"
             [ test "negative index as first argument returns the original list" <|


### PR DESCRIPTION
This PR addresses the logical error in `isInfixOf` discovered in #132. I added a unit test to prevent future regressions.

In the process of fixing the bug, I found a second unrelated issue in `isPrefixOf` that could cause a stack overflow for sufficiently large lists. (Since `isSuffixOf` and `isInfixOf` use `isPrefixOf` as a helper, they are also affected.) I added unit tests to make sure these functions do not cause a stack overflow in the future.

Lastly, I added some fuzz tests for `isPrefixOf`, `isSuffixOf`, and `isInfixOf`.