### PR TITLE
Add setBy

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1,6 +1,6 @@
 
 module List.Extra exposing
-    ( last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
+    ( last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, setBy, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
     , intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, uniquePairs
     , foldl1, foldr1, indexedFoldl, indexedFoldr
     , scanl, scanl1, scanr, scanr1, mapAccuml, mapAccumr, unfoldr, iterate, initialize, cycle
@@ -18,7 +18,7 @@ module List.Extra exposing
 
 # Basics
 
-@docs last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
+@docs last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, setBy, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
 
 
 # List transformations
@@ -696,6 +696,20 @@ count predicate =
 setIf : (a -> Bool) -> a -> List a -> List a
 setIf predicate replacement list =
     updateIf predicate (always replacement) list
+
+
+{-| Replace all values for which the given accessor returns the same value as
+for the replacement value.
+
+Mostly useful for cases when a value in a list should be replaced based on some identifying value.
+
+    setBy Tuple.first (1, 42) [ (3, 1), (2, 2), (1, 3) ]
+    --> [ (3, 1), (2, 2), (1, 42) ]
+
+-}
+setBy : (a -> b) -> a -> List a -> List a
+setBy accessor replacement =
+    setIf (\item -> accessor item == accessor replacement) replacement
 
 
 {-| Replace all values that satisfy a predicate by calling an update function.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -754,6 +754,22 @@ all =
                 \() ->
                     Expect.equal (setIf (\x -> modBy 2 x == 0) 0 [ 17, 8, 2, 9 ]) [ 17, 0, 0, 9 ]
             ]
+        , describe "setBy"
+            [ test "empty list" <|
+                \() -> Expect.equal (setBy Tuple.first ( 1, 42 ) []) []
+            , test "set one" <|
+                \() ->
+                    Expect.equal (setBy Tuple.first ( 1, 42 ) [ ( 3, 1 ), ( 2, 2 ), ( 1, 3 ) ])
+                        [ ( 3, 1 ), ( 2, 2 ), ( 1, 42 ) ]
+            , test "set all" <|
+                \() ->
+                    Expect.equal (setBy (always True) ( 1, 42 ) [ ( 3, 1 ), ( 2, 2 ), ( 1, 3 ) ])
+                        [ ( 1, 42 ), ( 1, 42 ), ( 1, 42 ) ]
+            , test "set none" <|
+                \() ->
+                    Expect.equal (setBy Tuple.second ( 1, 42 ) [ ( 3, 1 ), ( 2, 2 ), ( 1, 3 ) ])
+                        [ ( 3, 1 ), ( 2, 2 ), ( 1, 3 ) ]
+            ]
         , describe "gatherEquals"
             [ test "empty list" <|
                 \() ->


### PR DESCRIPTION
A utility function for cases that Ive ran into few times now and have had to write it every time so I figured I might as well create a pull request :)

Most often when I use this I need to replace a value in a list by ID or name, so I'd call this by saying:

`setBy .id value list`

which is much nicer than:

`setIf (\item -> item.id == value.id) value list`

(or the shorter `setIf (.id >> (==) value.id) value list` )

Let me know if there are any problems with this or if I've missed some utility that achieves the same.