### PR TITLE
fix RangeError of iterate

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -149,14 +149,14 @@ list and the iteration will continue with `f y`.
 -}
 iterate : (a -> Maybe a) -> a -> List a
 iterate f x =
-    iterateInner f x [] |> List.reverse
+    iterateHelp f x [] |> List.reverse
 
 
-iterateInner : (a -> Maybe a) -> a -> List a -> List a
-iterateInner f x acc =
+iterateHelp : (a -> Maybe a) -> a -> List a -> List a
+iterateHelp f x acc =
     case f x of
         Just x_ ->
-            iterateInner f x_ (x :: acc)
+            iterateHelp f x_ (x :: acc)
 
         Nothing ->
             x :: acc

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -149,16 +149,17 @@ list and the iteration will continue with `f y`.
 -}
 iterate : (a -> Maybe a) -> a -> List a
 iterate f x =
-    let
-        go y acc =
-            case f y of
-                Just y_ ->
-                    go y_ (y :: acc)
+    iterateInner f x [] |> List.reverse
 
-                Nothing ->
-                    y :: acc
-    in
-    go x [] |> List.reverse
+
+iterateInner : (a -> Maybe a) -> a -> List a -> List a
+iterateInner f x acc =
+    case f x of
+        Just x_ ->
+            iterateInner f x_ (x :: acc)
+
+        Nothing ->
+            x :: acc
 
 
 {-| Initialize a list of some length with some function.

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -149,12 +149,16 @@ list and the iteration will continue with `f y`.
 -}
 iterate : (a -> Maybe a) -> a -> List a
 iterate f x =
-    case f x of
-        Just x_ ->
-            x :: iterate f x_
+    let
+        go y acc =
+            case f y of
+                Just y_ ->
+                    go y_ (y :: acc)
 
-        Nothing ->
-            [ x ]
+                Nothing ->
+                    y :: acc
+    in
+    go x [] |> List.reverse
 
 
 {-| Initialize a list of some length with some function.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -303,6 +303,20 @@ all =
                                         3 * n + 1
                     in
                     Expect.equal (iterate collatz 13) [ 13, 40, 20, 10, 5, 16, 8, 4, 2, 1 ]
+            , test "should not raise RangeError" <|
+                \() ->
+                    let
+                        loop n =
+                            if n == 100000 then
+                                Nothing
+
+                            else
+                                Just (n + 1)
+
+                        _ =
+                            iterate loop 1
+                    in
+                    Expect.pass
             ]
         , describe "initialize" <|
             [ test "creates a list starting from zero" <|


### PR DESCRIPTION
`iterate` raises `RangeError: Maximum call stack size exceeded` when recursive function is called too many time(example bellow). Now I use tail recursive optimization to avoid this sort of error.

```elm
f n = if n == 100000 then Nothing else Just (n + 1)

iterate f 1
```