### PR TITLE
Speedup and simplify removeAt implementation

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -860,19 +860,7 @@ removeAt index l =
         l
 
     else
-        let
-            head =
-                List.take index l
-
-            tail =
-                List.drop index l |> List.tail
-        in
-        case tail of
-            Nothing ->
-                l
-
-            Just t ->
-                List.append head t
+        take index l ++ drop (index + 1) l
 
 
 {-| Remove an element at an index that satisfies a predicate.

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -860,7 +860,12 @@ removeAt index l =
         l
 
     else
-        take index l ++ drop (index + 1) l
+        case drop index l of
+            [] ->
+                l
+
+            _ :: rest ->
+                take index l ++ rest
 
 
 {-| Remove an element at an index that satisfies a predicate.


### PR DESCRIPTION
This is nothing major, but I found this when I optimised some my code with `removeAt` usage and tried custom implementation. 

I did few benchmarks and this shorter implementation is faster in most cases. It's slowly only for out of range action when index is bigger than list length. 

Here some results for different browsers:
**Chrome**
<img width="605" alt="Chrome" src="https://user-images.githubusercontent.com/5626634/75538222-8d074400-5a18-11ea-9291-ecee9b7d0364.png">

**Firefox** 
<img width="555" alt="Firefox" src="https://user-images.githubusercontent.com/5626634/75538245-955f7f00-5a18-11ea-9451-6062896832d0.png">

**Safari**
<img width="580" alt="Safari" src="https://user-images.githubusercontent.com/5626634/75538271-9e505080-5a18-11ea-8f1d-f5cc6682897f.png">


Here is benchmark code I used (only part)
```Elm
longList =
    List.range 1 10000


suite : Benchmark
suite =
    describe "removeAt in List.Extra"
        [ B.compare "removeAt on short list"
            "orignial List.Extra.removeAt"
            (\() -> List.removeAt 3 [ 1, 2, 3, 4, 5 ])
            "Short implementation"
            (\() -> removeAt 3 [ 1, 2, 3, 4, 5 ])
        , B.compare "removeAt on long list"
            "orignial List.Extra.removeAt"
            (\() -> List.removeAt 666 longList)
            "Short implementation"
            (\() -> removeAt 666 longList)
        , B.compare "removeAt invalid negative value"
            "orignial List.Extra.removeAt"
            (\() -> List.removeAt -666 longList)
            "Short implementation"
            (\() -> removeAt -666 longList)
        , B.compare "removeAt out of range possitive value"
            "orignial List.Extra.removeAt"
            (\() -> List.removeAt 100000 longList)
            "Short implementation"
            (\() -> removeAt 100000 longList)
        ]
```

