### PR TITLE
Implement `mapMaybe` function

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1,5 +1,5 @@
 module List.Extra exposing
-    ( last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
+    ( last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, mapMaybe, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
     , intercalate, transpose, subsequences, permutations, interweave, cartesianProduct, uniquePairs
     , foldl1, foldr1, indexedFoldl, indexedFoldr
     , scanl, scanl1, scanr, scanr1, mapAccuml, mapAccumr, unfoldr, iterate, initialize, cycle
@@ -16,7 +16,7 @@ module List.Extra exposing
 
 # Basics
 
-@docs last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
+@docs last, init, getAt, uncons, unconsLast, maximumBy, maximumWith, minimumBy, minimumWith, andMap, mapMaybe, andThen, reverseMap, takeWhile, dropWhile, unique, uniqueBy, allDifferent, allDifferentBy, setIf, setAt, remove, updateIf, updateAt, updateIfIndex, removeAt, removeIfIndex, filterNot, swapAt, stableSortWith
 
 
 # List transformations
@@ -721,6 +721,34 @@ findMap f list =
                 Nothing ->
                     findMap f tail
 
+
+{- | `mapMaybe` is a version of `map` which can throw out elements. In particular,
+the functional argument returns something of the type `Maybe b`. If this is `Nothing`,
+no element is added on to the result list. If it is `Just b`, then b is included in the result list.
+
+    mapMaybe Just [1, 2, 3]
+    --> [1, 2, 3]
+
+    mapMaybe Nothing [1, 2, 3]
+    --> []
+
+    mapMaybe String.toInt ["1", "foo", "bar", 4, 5]
+    --> [1, 4, 5]
+
+-}
+mapMaybe : (a -> Maybe b) -> List a -> List b
+mapMaybe f list =
+    case list of
+       [] -> 
+            []
+       
+       x :: xs ->
+            case f x of
+                Nothing -> 
+                    mapMaybe f xs
+                
+                Just v -> 
+                    v :: mapMaybe f xs
 
 {-| Returns the number of elements in a list that satisfy a given predicate.
 Equivalent to `List.length (List.filter pred list)` but more efficient.

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -732,7 +732,7 @@ no element is added on to the result list. If it is `Just b`, then b is included
     mapMaybe Nothing [1, 2, 3]
     --> []
 
-    mapMaybe String.toInt ["1", "foo", "bar", 4, 5]
+    mapMaybe String.toInt ["1", "foo", "bar", "4", "5"]
     --> [1, 4, 5]
 
 -}

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -35,6 +35,16 @@ all =
                         )
                         [ 9, 7, 9 ]
             ]
+        , describe "mapMaybe" <| 
+            [ test "returns a list only where f only yields Just" <|
+                \() ->
+                    Expect.equal
+                        (["1", "foo", "bar", "4", "5"]
+                            |> mapMaybe String.toInt
+                        )
+                        [1, 4, 5]
+
+            ]
         , describe "reverseMap" <|
             [ test "maps and reverses" <|
                 \() ->


### PR DESCRIPTION
I've implemented this a couple times in smaller personal projects of mine. I've seen this function implemented in the core libraries of [Haskell](https://hackage.haskell.org/package/base-4.15.0.0/docs/Data-Maybe.html#v:mapMaybe) and [F#](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-collections-listmodule.html#choose) (called `choose` in F#).

You can think of this function as doing a `filter` and `map` in one. Although this is a very contrived example, you an easily imagine one more complex:

```elm
[1, 2, 3, 4, 5]
  |> List.filter (\x -> x < 3)
  |> List.map (\x -> x * x)

-- Becomes:

perhapsSquareLessThanThree x =
  if x < 3
  then x * x |> Just
  else Nothing

mapMaybe perhapsSquareLessThanThree [1, 2, 3, 4, 5]
```

There are also other situation where you have a function that might return a `Maybe` and you can directly apply that function to a list of elements to only get back a list where it is `Just a`.

Let me know what you think. I'd love to hear thoughts!