### PR TITLE
Documentation fixup for findMap

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -702,9 +702,9 @@ This is particularly useful in cases where you have a complex type in a list, an
     viewFirstHomeOfInterest : Viewer -> List Property -> Html msg
     viewFirstHomeOfInterest viewer propertiesQuery =
         propertiesQuery
-            |> findMap toHome
+            |> findMap toHouse
             |> Maybe.map homeView
-            |> Maybe.withDefaultnoHomeView
+            |> Maybe.withDefault noHomeView
 
 -}
 findMap : (a -> Maybe b) -> List a -> Maybe b


### PR DESCRIPTION
The example defines a `toHouse` but pipes through `toHome`. Edit mistake, I'm sure.