### PR TITLE
Add group function for association lists

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -475,6 +475,13 @@ all =
                         (groupWhile (<) [ 1, 2, 3, 2, 4, 1, 3, 2, 1 ])
                         [ ( 1, [ 2, 3 ] ), ( 2, [ 4 ] ), ( 1, [ 3 ] ), ( 2, [] ), ( 1, [] ) ]
             ]
+        , describe "groupAssoc" <|
+            [ test "groups by key equality" <|
+                \() ->
+                    Expect.equal
+                        (groupAssoc [ ( 0, 'a' ), ( 1, 'c' ), ( 0, 'b' ), ( 1, 'd' ) ])
+                        [ ( 0, [ 'a', 'b' ] ), ( 1, [ 'c', 'd' ] ) ]
+            ]
         , describe "inits" <|
             [ test "returns all initial segments" <|
                 \() ->


### PR DESCRIPTION
I've added three functions: `groupAssoc`, `groupAssocBy` and `groupAssocWith`.

They all take lists in the form `List ( k, v )` and output `List ( k, List v )`.

A group of pairs `( k₁, v₁ ) ... ( kᵢ, vᵢ )` in our input where `kᵢ = k₂ = ... = kᵢ` will appear in our output as `( k₁, [ v₁, ..., vᵢ ] )`.
The equality in `groupAssocBy` and `groupAssocWith` can be defined as a user function just like in [List.sortBy](https://package.elm-lang.org/packages/elm/core/latest/List#sortBy) and [List.sortWith](https://package.elm-lang.org/packages/elm/core/latest/List#sortWith).

The use case is... well group things of course!

For example:

```elm
[ { name = "bob", age = 20 }
, { name = "alice", age = 25 }
, { name = "bob", age = 32 }
]
    |> List.map (\p -> ( p.name, p ))
    |> List.Extra.groupAssoc
```

gives

```elm
[ ( "alice", [ { age = 25, name = "alice" } ] )
, ( "bob", [ { age = 20, name = "bob" }, { age = 32, name = "bob" } ] )
]
```
<s>I'm sure the same could be done with `groupWhile`, but I find easier to get my head around `groupAssoc` </s>
EDIT: I've just seen [gatherEqualsBy](https://package.elm-lang.org/packages/elm-community/list-extra/latest/List-Extra#gatherEqualsBy), I guess the use cases collide with this one :smile: 

If there is interest I'll happily write some docs and other tests