### PR TITLE
Make gatherWith tail-call optimized

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -2017,6 +2017,6 @@ gatherWith testFn list =
                         ( gathering, remaining ) =
                             List.partition (testFn toGather) population
                     in
-                    helper remaining <| ( toGather, gathering ) :: gathered
+                    helper remaining (( toGather, gathering ) :: gathered)
     in
     helper list []


### PR DESCRIPTION
This makes `gatherWith` tail-call optimized. I haven't benchmarked it, but since there is no other significant change in this function, I can only imagine that the performance improved.

Note: I discovered this issue with https://package.elm-lang.org/packages/jfmengels/elm-review-performance/latest/