### PR TITLE
Make isInfixOf tail-call optimized

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1742,7 +1742,11 @@ isInfixOfHelp infixHead infixTail list =
 
         x :: xs ->
             if x == infixHead then
-                isPrefixOf infixTail xs || isInfixOfHelp infixHead infixTail xs
+                if isPrefixOf infixTail xs then
+                    True
+
+                else
+                    isInfixOfHelp infixHead infixTail xs
 
             else
                 isInfixOfHelp infixHead infixTail xs

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1741,12 +1741,8 @@ isInfixOfHelp infixHead infixTail list =
             False
 
         x :: xs ->
-            if x == infixHead then
-                if isPrefixOf infixTail xs then
-                    True
-
-                else
-                    isInfixOfHelp infixHead infixTail xs
+            if x == infixHead && isPrefixOf infixTail xs then
+                True
 
             else
                 isInfixOfHelp infixHead infixTail xs

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -659,6 +659,10 @@ all =
             , fuzz (list int) "equal lists are infix" <|
                 \list ->
                     Expect.true "equal lists are infix" (isInfixOf list list)
+            , test "is stack safe" <|
+                \() ->
+                    isInfixOf [ 5, 7, 13 ] (List.repeat 1000000 5)
+                        |> Expect.false "5, 7, 13 is not infix of 2, 3, 5, 7, 11, 13"
             ]
         , describe "swapAt"
             [ test "negative index as first argument returns the original list" <|


### PR DESCRIPTION
- Added test to check that isInfixOf is not stack-safe. Without the change, the tests fails because of a stack overflow.
- Made isInfixOf tail-call optimized in all branches

Becnhmark: https://ellie-app.com/dnQMpprLrDPa1

![Screenshot from 2021-06-05 23-32-04](https://user-images.githubusercontent.com/3869412/120906199-bcfbb900-c657-11eb-94d6-7bef91984cf7.png)



Note: There are still quite a few functions that can be optimized in this package, but I likely won't propose PRs for these, as they become a bit more complex.

You can run the following to find them:
```bash
npx elm-review --template jfmengels/elm-review-performance/example --rules NoUnoptimizedRecursion
```