### PR TITLE
Adds a joinOn function

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -878,4 +878,18 @@ all =
                     uniquePairs [ 1, 2, 3 ]
                         |> Expect.equal [ ( 1, 2 ), ( 1, 3 ), ( 2, 3 ) ]
             ]
+        , describe "joinOn"
+            [ test "with first list empty" <|
+                \() ->
+                    joinOn Tuple.pair identity identity [] [ 1, 2, 3 ]
+                        |> Expect.equal []
+            , test "with second list empty" <|
+                \() ->
+                    joinOn Tuple.pair identity identity [ 1, 2, 3 ] []
+                        |> Expect.equal []
+            , test "with neither list empty" <|
+                \() ->
+                    joinOn Tuple.pair identity identity [ 1, 3, 2 ] [ 2, 1, 3 ]
+                        |> Expect.equal [ ( 3, 3 ), ( 2, 2 ), ( 1, 1 ) ]
+            ]
         ]


### PR DESCRIPTION
This is a generic function for joining two datasets to each other. It's equivalent to an equijoin, for performance it utitlizes the [Sort-merge join algorithm](https://en.wikipedia.org/wiki/Sort-merge_join).

This gives it a O(|a| * log(|a|) + |b| * log(|b|)) complexity profile.

I've benchmarked it compared with the "obvious" implementation, which is

```elm
joinOn selectFn aKeyFn bKeyFn aList bList =
     List.concatMap (\a ->
         List.filterMap(\b ->
             if aKeyFn a == bKeyFn b then 
                 Just (selectFn a b)
            else
                Nothing
       ) bList
   ) aList
```

This implementation has the complexity of O(|a| * |b|).

This can be plainly seen in the benchmark results for the comparatively small case of 2 lists with 100 elements each:

<img width="590" alt="Screenshot 2021-07-30 at 16 25 42" src="https://user-images.githubusercontent.com/69144/127663188-364c5d6a-6c0c-421b-b785-edba37dc6a77.png">

<details>
  <summary>Benchmarking code here</summary>

```elm
module Benchmarking exposing (main)

import Benchmark exposing (Benchmark)
import Benchmark.Runner exposing (BenchmarkProgram, program)
import List.Extra exposing (joinOn)


main : BenchmarkProgram
main =
    program suite


n : Int
n =
    100


suite : Benchmark
suite =
    Benchmark.compare "simple vs optimized" "Simple" (\_ -> join select .d .d aList bList) "Optimized" (\_ -> joinOn select .d .d aList bList)


join selectFn aKeyFn bKeyFn aLst bLst =
    List.concatMap
        (\a ->
            List.filterMap
                (\b ->
                    if aKeyFn a == bKeyFn b then
                        Just (selectFn a b)

                    else
                        Nothing
                )
                bLst
        )
        aLst


aList =
    List.range 1 n
        |> List.map
            (\i ->
                { a = modBy 5 i
                , b = modBy 2 i
                , c = modBy 3 i
                , d = modBy 7 i
                , e = "Foo-" ++ String.fromInt i
                }
            )


bList =
    List.range 1 n
        |> List.map
            (\i ->
                { a = modBy 5 i
                , b = modBy 2 i
                , c = modBy 3 i
                , d = modBy 13 i
                , e = "Foo-" ++ String.fromInt i
                }
            )


select a b =
    { aa = a.a
    , ab = a.b
    , ac = a.c
    , ad = a.d
    , ae = a.e
    , ba = b.a
    , bb = b.b
    , bc = b.c
    , bd = b.d
    , be = b.e
    }
```
</details>