### PR TITLE
better performing `isPermutationOf`

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1807,10 +1807,7 @@ In other words: Do the 2 `List`s contain the same elements but in a different or
 isPermutationOf : List a -> List a -> Bool
 isPermutationOf permut xs =
     (length permut == length xs)
-        && (permut
-                |> List.all
-                    (\a -> xs |> member a)
-           )
+        && (permut |> all (\a -> xs |> member a))
 
 
 {-| Take two lists and returns a list of corresponding pairs

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1786,6 +1786,23 @@ isSubsequenceOf subseq list =
 
 
 {-| Take two lists and return `True`, if the first list is a permutation of the second list.
+In other words: Do the 2 `List`s contain the same elements but in a different order?
+
+    [ 3, 1, 2 ]
+        |> isPermutationOf
+            [ 1, 2, 3 ]
+    --> True
+
+    [ 3, 1, 0 ]
+        |> isPermutationOf
+            [ 1, 2, 3 ]
+    --> False
+
+    [ 3, 1, 2, 2 ]
+        |> isPermutationOf
+            [ 1, 2, 3 ]
+    --> False
+
 -}
 isPermutationOf : List a -> List a -> Bool
 isPermutationOf permut xs =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -440,7 +440,7 @@ allDifferent list =
     allDifferentBy identity list
 
 
-{-| Indicate if list has duplicate values when supplied function are applyed on each values.
+{-| Indicate if list has duplicate values when supplied function are applied on each values.
 -}
 allDifferentBy : (a -> comparable) -> List a -> Bool
 allDifferentBy f list =
@@ -1903,13 +1903,13 @@ groupsOfWithStep size step xs =
 
 -}
 groupsOfVarying : List Int -> List a -> List (List a)
-groupsOfVarying listOflengths list =
-    groupsOfVarying_ listOflengths list []
+groupsOfVarying listOfLengths list =
+    groupsOfVarying_ listOfLengths list []
 
 
 groupsOfVarying_ : List Int -> List a -> List (List a) -> List (List a)
-groupsOfVarying_ listOflengths list accu =
-    case ( listOflengths, list ) of
+groupsOfVarying_ listOfLengths list accu =
+    case ( listOfLengths, list ) of
         ( length :: tailLengths, _ :: _ ) ->
             let
                 ( head, tail ) =

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1789,7 +1789,11 @@ isSubsequenceOf subseq list =
 -}
 isPermutationOf : List a -> List a -> Bool
 isPermutationOf permut xs =
-    member permut (permutations xs)
+    (length permut == length xs)
+        && (permut
+                |> List.all
+                    (\a -> xs |> member a)
+           )
 
 
 {-| Take two lists and returns a list of corresponding pairs

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -163,6 +163,32 @@ all =
                         (permutations [ 1, 2, 3 ])
                         [ [ 1, 2, 3 ], [ 1, 3, 2 ], [ 2, 1, 3 ], [ 2, 3, 1 ], [ 3, 1, 2 ], [ 3, 2, 1 ] ]
             ]
+        , describe "isPermutationOf"
+            [ test "correctly notices permutations" <|
+                \() ->
+                    Expect.all
+                        ([ [ 1, 2, 3 ], [ 1, 3, 2 ], [ 2, 1, 3 ], [ 2, 3, 1 ], [ 3, 1, 2 ], [ 3, 2, 1 ] ]
+                            |> List.map
+                                (\permutation () ->
+                                    permutation
+                                        |> isPermutationOf [ 1, 2, 3 ]
+                                        |> Expect.equal True
+                                )
+                        )
+                        ()
+            , test "correctly notices non-permutations" <|
+                \() ->
+                    Expect.all
+                        ([ [], [ 1, 3 ], [ 2, 1, 3, 2 ], [ 4, 3, 1 ] ]
+                            |> List.map
+                                (\nonPermutation () ->
+                                    [ 1, 2, 3 ]
+                                        |> isPermutationOf nonPermutation
+                                        |> Expect.equal False
+                                )
+                        )
+                        ()
+            ]
         , describe "interweave" <|
             [ test "interweaves lists of equal length" <|
                 \() ->


### PR DESCRIPTION
`isPermutationOf` is implemented as
```elm
isPermutationOf permut xs =
    member permut (permutations xs)
```
It first calculates all **n! permutations**, then looks if the given list matches any. This makes `isPermutationOf` a very heavy operation:
![grafik](https://user-images.githubusercontent.com/81869893/130355730-7203d005-fc3f-4b53-87ac-8d9c297ceba3.png)
[ellie][ellie]

We can do the same job in O(n^2) time:
```elm
isPermutationOf permut xs =
    (length permut == length xs)
        && (permut |> all (\a -> xs |> member a))
```
You could also remove elements you already checked from the second list but in effect, both implementations perform equally as good.
![grafik](https://user-images.githubusercontent.com/81869893/130356076-6d7d53c6-d682-41e2-be0f-3686b7289833.png)
[ellie][ellie]

The PR also adds tests and examples for the new `isPermutationOf` and fixes a spelling mistake (applyed) in the `allDifferentBy` doc.

[ellie]: https://ellie-app.com/f5pWDmnpmhva1