### PR TITLE
isPermutationOf: Add an edge-case the fuzz test missed

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -184,6 +184,10 @@ all =
                 \() ->
                     isPermutationOf [1,1,1] [1,2,3]
                         |> Expect.equal False
+            , test "Notices that 1,1,2 is not a permutation of 1,2,2" <|
+                \() ->
+                    isPermutationOf [ 1, 1, 2 ] [ 1, 2, 2 ]
+                        |> Expect.equal False
             , test "correctly notices non-permutations" <|
                 \() ->
                     Expect.all


### PR DESCRIPTION
The edge case actually helped disprove the validity of the implementation of `isPermutationOf` that I had in my head:

```elm
isPermutationOf xs ys =
  (List.length xs == List.length ys)
    && List.all (\x -> List.member x ys) xs
    && List.all (\y -> List.member y xs) ys
```