### PR TITLE
updateAt: Avoid computing head when unnecessary

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -815,17 +815,15 @@ updateAt index fn list =
 
     else
         let
-            head =
-                List.take index list
-
+            tail : List a
             tail =
                 List.drop index list
         in
         case tail of
             x :: xs ->
-                head ++ fn x :: xs
+                List.take index list ++ fn x :: xs
 
-            _ ->
+            [] ->
                 list
 
 


### PR DESCRIPTION
This makes it so that we don't unnecessarily compute `head` in the case where the tail is empty.