### PR TITLE
Make remove tail-call optimized

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -854,16 +854,21 @@ updateIfIndex predicate update list =
 -}
 remove : a -> List a -> List a
 remove x xs =
+    removeHelp xs x xs []
+
+
+removeHelp : List a -> a -> List a -> List a -> List a
+removeHelp list x xs previousElements =
     case xs of
         [] ->
-            []
+            list
 
         y :: ys ->
             if x == y then
-                ys
+                reverseAppend previousElements ys
 
             else
-                y :: remove x ys
+                removeHelp list x ys (y :: previousElements)
 
 
 {-| Set a value in a list by index. Return the original list if the index is out of range.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -165,9 +165,9 @@ all =
             ]
         , describe "isPermutationOf"
             [ fuzz2 (list int) (list int) "works the same as sorting" <|
-                    \a b ->
-                        isPermutationOf a b
-                            |> Expect.equal (List.sort a == List.sort b)
+                \a b ->
+                    isPermutationOf a b
+                        |> Expect.equal (List.sort a == List.sort b)
             , test "correctly notices permutations" <|
                 \() ->
                     Expect.all
@@ -182,7 +182,7 @@ all =
                         ()
             , test "Notices that 1,1,1 is not a permutation of 1,2,3" <|
                 \() ->
-                    isPermutationOf [1,1,1] [1,2,3]
+                    isPermutationOf [ 1, 1, 1 ] [ 1, 2, 3 ]
                         |> Expect.equal False
             , test "Notices that 1,1,2 is not a permutation of 1,2,2" <|
                 \() ->

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -788,6 +788,28 @@ all =
                 \() ->
                     Expect.equal (updateIfIndex (\index -> modBy 2 index == 0) ((+) 1) [ 1, 2, 3 ]) [ 2, 2, 4 ]
             ]
+        , describe "remove"
+            [ test "leaves the list untouched if the value is not in the list" <|
+                \() ->
+                    let
+                        list : List Int
+                        list =
+                            [ 1, 2, 3 ]
+                    in
+                    list
+                        |> remove 1000
+                        |> Expect.equal list
+            , test "removes the element if it's present in the list" <|
+                \() ->
+                    [ 1, 2, 3 ]
+                        |> remove 2
+                        |> Expect.equal [ 1, 3 ]
+            , test "removes only the first element" <|
+                \() ->
+                    [ 1, 2, 3, 3, 3 ]
+                        |> remove 3
+                        |> Expect.equal [ 1, 2, 3, 3 ]
+            ]
         , describe "removeIfIndex"
             [ test "remove all the elements" <|
                 \() ->

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -809,6 +809,16 @@ all =
                     [ 1, 2, 3, 3, 3 ]
                         |> remove 3
                         |> Expect.equal [ 1, 2, 3, 3 ]
+            , test "is stack-safe" <|
+                \() ->
+                    let
+                        list : List Int
+                        list =
+                            List.range 1 10000
+                    in
+                    list
+                        |> remove 100000
+                        |> Expect.equal list
             ]
         , describe "removeIfIndex"
             [ test "remove all the elements" <|


### PR DESCRIPTION
This makes `remove` tail-call optimized, meaning it will not blow up the stack when working on lists that are too large.

|This also improves performance:](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ListExtra/Remove.elm)


![Screenshot from 2021-12-18 10-50-05](https://user-images.githubusercontent.com/3869412/146637922-927db029-0dd9-42bf-b9d8-286a2f9b0037.png)


I also special-cased the case where the element is not found so that we don't unnecessarily recreate the entire list from the accumulator.


I also added tests for `remove` and applied elm-format (seems like tests weren't properly formatted).