### PR TITLE
Add a stricter test for stoppableFoldl behaviour

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -993,5 +993,30 @@ all =
                         0
                         (List.range 1 1000)
                         |> Expect.equal 55
+            , test "after Stop, the function is not called anymore" <|
+                let
+                    throwRangeErrorException : () -> a
+                    throwRangeErrorException () =
+                        preventTailCallOptimization ()
+
+                    preventTailCallOptimization : () -> a
+                    preventTailCallOptimization () =
+                        throwRangeErrorException ()
+                in
+                \() ->
+                    stoppableFoldl
+                        (\n acc ->
+                            if n < 50 then
+                                Continue n
+
+                            else if n == 50 then
+                                Stop n
+
+                            else
+                                explode ()
+                        )
+                        0
+                        (List.range 1 1000)
+                        |> Expect.equal 50
             ]
         ]


### PR DESCRIPTION
@adamnfish has found that the tests for `List.Extra.stoppableFoldl` aren't really testing the main promise of the function: that it will stop running the function after a `Stop` is returned.

Together we're adding a test which will throw a RangeError (stack overflow) if `stoppableFoldl` goes through the whole list. We've verified it by temporarily changing the implementation of `stoppableFoldl` to just be a `List.foldl`.