### PR TITLE
Speed up minimumBy and maximumBy

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -298,8 +298,10 @@ unconsLast list =
 maximumBy : (a -> comparable) -> List a -> Maybe a
 maximumBy f ls =
     let
-        maxBy x ( y, fy ) =
+        maxBy : a -> ( a, comparable ) -> ( a, comparable )
+        maxBy x (( _, fy ) as max) =
             let
+                fx : comparable
                 fx =
                     f x
             in
@@ -307,7 +309,7 @@ maximumBy f ls =
                 ( x, fx )
 
             else
-                ( y, fy )
+                max
     in
     case ls of
         [ l_ ] ->

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -350,8 +350,10 @@ maximumWith comparator list =
 minimumBy : (a -> comparable) -> List a -> Maybe a
 minimumBy f ls =
     let
-        minBy x ( y, fy ) =
+        minBy : a -> ( a, comparable ) -> ( a, comparable )
+        minBy x (( _, fy ) as min) =
             let
+                fx : comparable
                 fx =
                     f x
             in
@@ -359,7 +361,7 @@ minimumBy f ls =
                 ( x, fx )
 
             else
-                ( y, fy )
+                min
     in
     case ls of
         [ l_ ] ->


### PR DESCRIPTION
This PR speeds up these 2 functions.

The change is that we don't recreate tuples unnecessary, which does have a cost.

I made [some benchmarks](https://github.com/jfmengels/elm-benchmarks/blob/master/src/ImprovingPerformance/ListExtra/MinimumBy.elm) (only for `minimumBy`, but it's the same for `maximumBy`).

## Results on Chrome

![](https://raw.githubusercontent.com/jfmengels/elm-benchmarks/master/src/ImprovingPerformance/ListExtra/MinimumBy-Results-Chrome.png)

## Results on Firefox

![](https://raw.githubusercontent.com/jfmengels/elm-benchmarks/master/src/ImprovingPerformance/ListExtra/MinimumBy-Results-FF.png)