### PR TITLE
Optimize List.Extra.init (changing the type signature)

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -100,23 +100,15 @@ last items =
 {-| Return all elements of the list except the last one.
 
     init [ 1, 2, 3 ]
-    --> Just [ 1, 2 ]
+    --> [ 1, 2 ]
 
     init []
-    --> Nothing
+    --> []
 
 -}
-init : List a -> Maybe (List a)
+init : List a -> List a
 init items =
-    case items of
-        [] ->
-            Nothing
-
-        nonEmptyList ->
-            nonEmptyList
-                |> List.reverse
-                |> List.tail
-                |> Maybe.map List.reverse
+    List.take (List.length items - 1) items
 
 
 {-| Returns `Just` the element at the given index in the list,

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -393,13 +393,13 @@ all =
         , describe "init" <|
             [ test "handles an empty list" <|
                 \() ->
-                    Expect.equal (init []) Nothing
+                    Expect.equal (init []) []
             , fuzz int "handles a nearly-empty list" <|
                 \x ->
-                    Expect.equal (init [ x ]) (Just [])
+                    Expect.equal (init [ x ]) []
             , fuzz2 (list int) int "handles a non-empty list" <|
                 \list x ->
-                    Expect.equal (init <| list ++ [ x ]) (Just list)
+                    Expect.equal (init <| list ++ [ x ]) list
             ]
         , describe "initialize" <|
             [ test "creates a list starting from zero" <|


### PR DESCRIPTION
This uses `length` and `take` on the list instead of two `reverse`s.

Benchmark: https://gist.github.com/Janiczek/67a106dbfdd18d029f99522868bd5126

EDIT: I forgot to pass `items` to the second algorithm! 🤦🤦🤦🤦🤦 

Here are the new, correct benchmarks:

Safari:

<img width="638" alt="Screenshot 2023-01-11 at 18 45 51" src="https://user-images.githubusercontent.com/149425/211880086-020b8e3c-a53c-4f6d-9723-987a2829bc05.png">

Chrome:

<img width="685" alt="Screenshot 2023-01-11 at 18 46 06" src="https://user-images.githubusercontent.com/149425/211880114-bcff42e4-ceb0-4c0e-b84b-283aaf24cf58.png">

I guess it doesn't make sense to merge this now.